### PR TITLE
GCloud deploy issue

### DIFF
--- a/admin/howto.txt
+++ b/admin/howto.txt
@@ -65,3 +65,30 @@ Create it using travis GUI
 
 -For memory profiling
 guppy / heapy
+
+
+######## How to debug gcloud app deploy failure ########
+
+Reference: https://github.com/GoogleCloudPlatform/python-runtime
+
+Docker need to be installed
+
+This procedure allow to generate the docker image used by google to run our app.
+
+- To generate a Dockerfile and a .dockerignore, run the bellow command in src/server/server 
+gcloud beta app gen-config --custom
+
+- Build the docker image using
+docker build -t "whatever_you_want:whatever_you_want" .
+
+- To be able to run the image locally, two more steps are needed
+    - create a service account and generate/download a private json key from : https://console.cloud.google.com/iam-admin/serviceaccounts/project?project=gator-01
+    - put the generate json key on src/server/server
+    - open the Dockerfile and add the line "ENV GOOGLE_APPLICATION_CREDENTIALS generate_key_name.json" before "CMD gunicorn -b :$PORT main:APP"
+    - IMPORTANT: After debugging, delete the generate key (locally and on google cloud console)
+
+- Run the image
+docker run -i -t whatever_you_want:whatever_you_want
+
+- The app is then accessible at
+http://localhost:8080/

--- a/src/server/server/app.yaml
+++ b/src/server/server/app.yaml
@@ -1,5 +1,8 @@
 runtime: python
 vm: true
+# In the last parameter passed to gunicorn,
+# - main is the module name (the associated file is thus main.py) containing the web app
+# - APP is the variable name of the web app in the module
 entrypoint: gunicorn -b :$PORT main:APP
 
 runtime_config:

--- a/src/server/server/app.yaml
+++ b/src/server/server/app.yaml
@@ -1,6 +1,6 @@
 runtime: python
 vm: true
-entrypoint: gunicorn -b :$PORT main:app
+entrypoint: gunicorn -b :$PORT main:APP
 
 runtime_config:
   python_version: 2

--- a/src/server/server/main.py
+++ b/src/server/server/main.py
@@ -4,7 +4,8 @@ from flask import Flask
 from environment import IS_TEST_ENV  # pylint: disable=relative-import
 from handlers import handlers  # pylint: disable=relative-import
 
-
+# As this variable is referenced by gunicorn in entrypoint section of app.yaml file, if changed, the gunicorn command must
+# be updated accordingly
 APP = Flask(__name__)
 APP.register_blueprint(handlers)
 APP.secret_key = 'maybe_we_should_generate_a_random_key'


### PR DESCRIPTION
GCloud was failing because the name of the object representing our app was "APP" not "app"

I update howto.txt with a new section "How to debug gcloud app deploy failure", this section contains the steps I followed to spot the deploy problem