### PR TITLE
Replace conda workaround by standard pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: python
+cache: pip
 python:
 - '2.7'
 before_install:
 - openssl aes-256-cbc -K $encrypted_411bc28b64b2_key -iv $encrypted_411bc28b64b2_iv
   -in client-secret.json.enc -out client-secret.json -d
-- mkdir lib_travis
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-- chmod +x miniconda.sh
-- ./miniconda.sh -b -p ./lib_travis/miniconda
-- export PATH=$(pwd)/lib_travis/miniconda/bin:$PATH
-- conda update --yes conda
 install:
-- conda install --yes python=$TRAVIS_PYTHON_VERSION cryptography numpy scipy
 - tools/install_envs.sh
 - pip install coveralls
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ urllib3
 simplejson
 requests
 cchardet
+numpy
+scipy
 gensim
 nltk
 boilerpipe

--- a/tools/install_envs.sh
+++ b/tools/install_envs.sh
@@ -6,9 +6,10 @@ mkdir -p lib
 
 rm -rf lib/google-cloud-sdk
 wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-119.0.0-linux-x86_64.tar.gz -nv
-tar zxvf google-cloud-sdk-119.0.0-linux-x86_64.tar.gz -C lib
+tar zxf google-cloud-sdk-119.0.0-linux-x86_64.tar.gz -C lib
 rm google-cloud-sdk-119.0.0-linux-x86_64.tar.gz
 
+pip install -U pip # we need a recent version of pip so that pip install scipy/numpy works
 pip install -r requirements.txt
 pip install -r test_requirements.txt
 # server unit tests are run in this "default" env so we need server requirements in it


### PR DESCRIPTION
It recent versions of pip, pip install works for packages with C dependencies (numpy/scipy). It downloads compatible binaries instead of recompiling all C deps from scratch, which was why we used conda before.

Some minor related changes:
-Activate pip cache to get faster execution of install_envs (it seems to do the right thing, ie: if I remove a dependency from requirement, it will not load it from cache because we still create a new virtual env for each build)
-Add dependency to numpy/scipy in requirement because we import it explicitly in our code (it was here because of gensim/nltk)
-Add pip update in install_envs to make pip works
-Remove verbose mode form tar command to not pollute travis logs

cf.:
-https://pip.pypa.io/en/stable/news/ PEP513
-https://mail.scipy.org/pipermail/numpy-discussion/2016-April/075365.html
-https://github.com/matthew-brett/manylinux-testing