### PR TITLE
Replace boilerpipe by readability-lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+readability-lxml
 jsonpickle
 praw
 pyopenssl
@@ -9,6 +10,5 @@ requests
 cchardet
 gensim
 nltk
-boilerpipe
 gcloud
 pytz

--- a/src/functests/test_homepage.py
+++ b/src/functests/test_homepage.py
@@ -4,6 +4,7 @@
 import time
 import unittest
 from _socket import timeout
+from selenium.common.exceptions import TimeoutException
 from selenium import webdriver
 from server import frontendstructs as structs, passwordhelpers as passwordhelpers
 from server.dal import Dal, REF_FEATURE_SET
@@ -22,7 +23,7 @@ def with_retry(action):
         try:
             action()
             break
-        except timeout:
+        except (timeout, TimeoutException):
             pass
     else:
         raise timeout

--- a/src/topicmodeller/topicmodeller/doctokenizer.py
+++ b/src/topicmodeller/topicmodeller/doctokenizer.py
@@ -3,14 +3,17 @@
 import re
 import nltk
 from nltk.corpus import stopwords
-from boilerpipe.extract import Extractor
-
+from readability import Document
+import lxml
 
 # Extract a readable document from HTML
+
+
 def _readable_document(html_document):
-    extractor = Extractor(extractor=u'ArticleExtractor', html=html_document)
-    text = extractor.getText()
-    return text
+    readability_doc = Document(html_document)
+    text_without_useless_parts = readability_doc.summary()
+    text_without_html_markup = lxml.html.fromstring(text_without_useless_parts).text_content()
+    return text_without_html_markup
 
 
 def _word_tokenize(content):


### PR DESCRIPTION
boilepipe has a java dependency and doesn't install correctly with pip anymore
readability is pure python, so it simplifies the setup