### PR TITLE
Add logic to convert an vector from a topic model to another

### DIFF
--- a/src/functests/daltesthelpers.py
+++ b/src/functests/daltesthelpers.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import server.frontendstructs as struct
-from server.dal import Dal, REF_FEATURE_SET
+from server.dal import Dal
 
 
 def create_user_dummy(user_id, password, interests):
     dal = Dal()
+    ref_feature_set_id = dal.feature_set.get_ref_feature_set_id()
     dummy_doc1 = struct.Document.make_from_scratch(
         url='https://www.google.com', url_hash='hash_create_user_dummy_1_' + user_id, title='google.com',
         summary='we will buy you',
-        feature_vector=struct.FeatureVector.make_from_scratch([], REF_FEATURE_SET))
+        feature_vector=struct.FeatureVector.make_from_scratch([], ref_feature_set_id))
     dummy_doc2 = struct.Document.make_from_scratch(
         url='gator.life', url_hash='hash_create_user_dummy_2_' + user_id, title='gator.life', summary='YGNI',
-        feature_vector=struct.FeatureVector.make_from_scratch([], REF_FEATURE_SET))
+        feature_vector=struct.FeatureVector.make_from_scratch([], ref_feature_set_id))
     dal.doc.save_documents([dummy_doc1, dummy_doc2])
 
     new_user = struct.User.make_from_scratch(email=user_id, interests=interests)

--- a/src/functests/daltesthelpers.py
+++ b/src/functests/daltesthelpers.py
@@ -27,7 +27,7 @@ def create_user_dummy(user_id, password, interests):
 def init_features_dummy(feature_set_id):
     dal = Dal()
     dal.feature_set.save_feature_set(
-        struct.FeatureSet.make_from_scratch(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++']))
+        struct.FeatureSet.make_from_scratch(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++'], model_id=None))
 
 
 NEW_USER_ID = "new_user_id"

--- a/src/functests/daltesthelpers.py
+++ b/src/functests/daltesthelpers.py
@@ -26,7 +26,8 @@ def create_user_dummy(user_id, password, interests):
 
 def init_features_dummy(feature_set_id):
     dal = Dal()
-    dal.feature_set.save_features(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++'])
+    dal.feature_set.save_feature_set(
+        struct.FeatureSet.make_from_scratch(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++']))
 
 
 NEW_USER_ID = "new_user_id"

--- a/src/functests/daltesthelpers.py
+++ b/src/functests/daltesthelpers.py
@@ -13,20 +13,20 @@ def create_user_dummy(user_id, password, interests):
     dummy_doc2 = struct.Document.make_from_scratch(
         url='gator.life', url_hash='hash_create_user_dummy_2_' + user_id, title='gator.life', summary='YGNI',
         feature_vector=struct.FeatureVector.make_from_scratch([], REF_FEATURE_SET))
-    dal.save_documents([dummy_doc1, dummy_doc2])
+    dal.doc.save_documents([dummy_doc1, dummy_doc2])
 
     new_user = struct.User.make_from_scratch(email=user_id, interests=interests)
-    dal.save_user(new_user, password)
+    dal.user.save_user(new_user, password)
     user_doc1 = struct.UserDocument.make_from_scratch(document=dummy_doc1, grade=1.0)
     user_doc2 = struct.UserDocument.make_from_scratch(document=dummy_doc2, grade=0.5)
-    dal.save_user_docs(new_user, [user_doc1, user_doc2])
+    dal.user_doc.save_user_docs(new_user, [user_doc1, user_doc2])
 
     return new_user
 
 
 def init_features_dummy(feature_set_id):
     dal = Dal()
-    dal.save_features(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++'])
+    dal.feature_set.save_features(feature_set_id, feature_names=['sport', 'trading', 'bmw', 'c++'])
 
 
 NEW_USER_ID = "new_user_id"

--- a/src/functests/test_homepage.py
+++ b/src/functests/test_homepage.py
@@ -94,7 +94,7 @@ class NewVisitorTests(unittest.TestCase):
         interests_str = 'finance\npython\ncomputer science'
         self._register(email, 'password', interests_str)
 
-        user = self.dal.get_user(email)
+        user = self.dal.user.get_user(email)
         self.assertIsNotNone(user)
         self.assertItemsEqual(user.interests, interests_str.splitlines())
         self.assertItemsEqual(user.interests, interests_str.splitlines())
@@ -165,7 +165,7 @@ class NewVisitorTests(unittest.TestCase):
         self._click(google_link)
         self.assertEqual("Google", self.browser.title)
 
-        actions_by_user = self.dal.get_user_actions_on_docs([user], now)
+        actions_by_user = self.dal.user_action.get_user_actions_on_docs([user], now)
 
         actions = actions_by_user[0]
         self.assertEqual(3, len(actions))

--- a/src/functests/test_homepage.py
+++ b/src/functests/test_homepage.py
@@ -7,7 +7,7 @@ from _socket import timeout
 from selenium.common.exceptions import TimeoutException
 from selenium import webdriver
 from server import frontendstructs as structs, passwordhelpers as passwordhelpers
-from server.dal import Dal, REF_FEATURE_SET
+from server.dal import Dal
 from common.datehelper import utcnow
 import daltesthelpers
 
@@ -38,15 +38,14 @@ class NewVisitorTests(unittest.TestCase):
     def _click(element):
         with_retry(element.click)
 
-    @classmethod
-    def setUpClass(cls):
-        daltesthelpers.init_features_dummy(REF_FEATURE_SET)
-
     def setUp(self):
         self.browser = webdriver.PhantomJS()
         self.browser.implicitly_wait(3)
         self.browser.set_page_load_timeout(60)
         self.dal = Dal()
+        ref_feature_set_id = 'ref_feature_set_id_NewVisitorTests'
+        self.dal.feature_set.save_ref_feature_set_id(ref_feature_set_id)
+        daltesthelpers.init_features_dummy(ref_feature_set_id)
 
     def tearDown(self):
         self.browser.quit()

--- a/src/functests/test_launch_scrap_and_learn.py
+++ b/src/functests/test_launch_scrap_and_learn.py
@@ -14,37 +14,38 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
         self.dal = Dal()
         nb_topics_trained_model = 500
         self.dal.save_features(REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)])
+        self.is_coverage = bool(os.environ.get('COVERAGE', None))
 
     def test_launch_scrap_and_learn(self):
         user_name = 'test_launch_scrap_and_learn'
         nb_docs = str(10)
         user = structinit.create_user_in_db(user_name, [], 'pass', self.dal)
-        docker_image_name = "scrap_learn"
-        model_directory_in_docker_image = "trained_topic_model"
-        cassette_path_in_docker_image = "src/functests/vcr_cassettes/test_launch_scrap_and_learn.yaml"
-        local_datastore = "http://localhost:33001"
-
         directory = os.path.dirname(os.path.abspath(__file__))
         root_dir = directory + '/../..'
-        subprocess.call(["tools/build_docker_scrap_learn.sh"], cwd=root_dir, shell=True)
-        subprocess.call(['docker', 'run',
-                         "--net=host",  # so container can access local datastore address
-                         "-e", "TEST_ENV=True",
-                         "-e", "DATASTORE_HOST=" + local_datastore,
-                         docker_image_name,
-                         model_directory_in_docker_image,
-                         cassette_path_in_docker_image,
-                         user_name,
-                         nb_docs])
 
-        # ---------replace docker call by direct call below for debugging-----------
-        # import sys
-        # from orchestrator.scrap_and_learn import scrap_and_learn
-        # cassette_file = directory + '/vcr_cassettes/test_launch_scrap_and_learn.yaml'
-        # model_dir = root_dir + '/docker_images/gator_deps/trained_topic_model'
-        # sys.argv = [None, model_dir, cassette_file, user_name, 10]
-        # scrap_and_learn()
-        # ------------------------------------------------------------------------
+        if not self.is_coverage:
+            docker_image_name = "scrap_learn"
+            model_directory_in_docker_image = "trained_topic_model"
+            cassette_path_in_docker_image = "src/functests/vcr_cassettes/test_launch_scrap_and_learn.yaml"
+            local_datastore = "http://localhost:33001"
+
+            subprocess.call(["tools/build_docker_scrap_learn.sh"], cwd=root_dir, shell=True)
+            subprocess.call(['docker', 'run',
+                             "--net=host",  # so container can access local datastore address
+                             "-e", "TEST_ENV=True",
+                             "-e", "DATASTORE_HOST=" + local_datastore,
+                             docker_image_name,
+                             model_directory_in_docker_image,
+                             cassette_path_in_docker_image,
+                             user_name,
+                             nb_docs])
+        else:
+            import sys
+            from orchestrator.scrap_and_learn import scrap_and_learn
+            cassette_file = directory + '/vcr_cassettes/test_launch_scrap_and_learn.yaml'
+            model_dir = root_dir + '/docker_images/gator_deps/trained_topic_model'
+            sys.argv = [None, model_dir, cassette_file, user_name, nb_docs]
+            scrap_and_learn()
 
         user_docs = self.dal.get_users_docs([user])[0]
         self.assertTrue(len(user_docs) > 6)  # some docs are filtered because not classified

--- a/src/functests/test_launch_scrap_and_learn.py
+++ b/src/functests/test_launch_scrap_and_learn.py
@@ -13,7 +13,7 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
     def setUp(self):
         self.dal = Dal()
         nb_topics_trained_model = 500
-        self.dal.save_features(REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)])
+        self.dal.feature_set.save_features(REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)])
         self.is_coverage = bool(os.environ.get('COVERAGE', None))
 
     def test_launch_scrap_and_learn(self):
@@ -47,7 +47,7 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
             sys.argv = [None, model_dir, cassette_file, user_name, nb_docs]
             scrap_and_learn()
 
-        user_docs = self.dal.get_users_docs([user])[0]
+        user_docs = self.dal.user_doc.get_users_docs([user])[0]
         self.assertTrue(len(user_docs) > 6)  # some docs are filtered because not classified
         sorted_docs = sorted(user_docs, key=lambda u: u.grade, reverse=True)
         for doc in sorted_docs[:3]:  # the first user docs should have a significant value

--- a/src/functests/test_launch_scrap_and_learn.py
+++ b/src/functests/test_launch_scrap_and_learn.py
@@ -4,7 +4,7 @@
 import unittest
 import os
 import subprocess32 as subprocess
-from server.dal import Dal, REF_FEATURE_SET
+from server.dal import Dal
 from server.frontendstructs import FeatureSet
 import server.structinit as structinit
 
@@ -14,8 +14,10 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
     def setUp(self):
         self.dal = Dal()
         nb_topics_trained_model = 500
+        ref_feature_set_id = 'ref_feature_set_id_LaunchScrapAndLearnTests'
+        self.dal.feature_set.save_ref_feature_set_id(ref_feature_set_id)
         self.dal.feature_set.save_feature_set(FeatureSet.make_from_scratch(
-            REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)], "TODO"))
+            ref_feature_set_id, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)], "TODO"))
         self.is_coverage = bool(os.environ.get('COVERAGE', None))
 
     def test_launch_scrap_and_learn(self):

--- a/src/functests/test_launch_scrap_and_learn.py
+++ b/src/functests/test_launch_scrap_and_learn.py
@@ -5,6 +5,7 @@ import unittest
 import os
 import subprocess32 as subprocess
 from server.dal import Dal, REF_FEATURE_SET
+from server.frontendstructs import FeatureSet
 import server.structinit as structinit
 
 
@@ -13,7 +14,8 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
     def setUp(self):
         self.dal = Dal()
         nb_topics_trained_model = 500
-        self.dal.feature_set.save_features(REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)])
+        self.dal.feature_set.save_feature_set(FeatureSet.make_from_scratch(
+            REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)]))
         self.is_coverage = bool(os.environ.get('COVERAGE', None))
 
     def test_launch_scrap_and_learn(self):

--- a/src/functests/test_launch_scrap_and_learn.py
+++ b/src/functests/test_launch_scrap_and_learn.py
@@ -15,7 +15,7 @@ class LaunchScrapAndLearnTests(unittest.TestCase):
         self.dal = Dal()
         nb_topics_trained_model = 500
         self.dal.feature_set.save_feature_set(FeatureSet.make_from_scratch(
-            REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)]))
+            REF_FEATURE_SET, ['feature_' + str(i) for i in range(0, nb_topics_trained_model)], "TODO"))
         self.is_coverage = bool(os.environ.get('COVERAGE', None))
 
     def test_launch_scrap_and_learn(self):

--- a/src/learner/learner/topic_model_converter.py
+++ b/src/learner/learner/topic_model_converter.py
@@ -1,0 +1,71 @@
+from itertools import chain, izip
+import numpy as np
+
+
+class TopicModelConverter(object):
+    """
+    Service to convert a feature vector expressed in a origin topic model to the best approximation
+    of this vector in a target topic model.
+    """
+
+    def __init__(self, origin_model, target_model):
+        """
+        :param origin_model: list of topics of "old" model, each topic is a list of tuple (word, weight)
+        :param target_model: list of topics of "new" model, each topic is a list of tuple (word, weight)
+        """
+        words = set(word for topic in chain(origin_model, target_model) for (word, _) in topic)  # unique words
+        word_to_index = dict(izip(words, range(len(words))))
+        origin_model_basis = self._build_basis_matrix(word_to_index, origin_model)
+        target_model_basis = self._build_basis_matrix(word_to_index, target_model)
+        self._projector = _VectorSpaceProjector(origin_model_basis, target_model_basis)
+
+    @staticmethod
+    def _build_basis_matrix(word_to_index, model):
+        model_basis = np.zeros((len(word_to_index), len(model)))
+        for index_topic, topic in enumerate(model):
+            for word, weight in topic:
+                model_basis[word_to_index[word], index_topic] = weight
+        return model_basis
+
+    def compute_target_vector(self, origin_vector):
+        """
+        :param origin_vector: classification of element (doc or user profile) in origin_model,
+        list of double of size origin_model.nb_topics
+        :return: approximation of classification of this element (doc or user profile) in target_model
+        list of double of size target_model.nb_topics
+        """
+        np_origin_vector = np.asarray(origin_vector)
+        np_target_vector = self._projector.project_on_target_space(np_origin_vector)
+        target_vector = np_target_vector.tolist()
+        return target_vector
+
+
+class _VectorSpaceProjector(object):
+    """
+    Service to project a vector from a subspace to another inside a common vector space
+    """
+
+    def __init__(self, origin_space_basis, target_space_basis):
+        """
+        :param origin_space_basis: numpy matrix dim_global_space * dim_origin_subspace
+        :param target_space_basis: numpy matrix dim_global_space * dim_target_subspace
+        -let's call A and B the matrices where each column 'i' is the coordinates of i-th base vector of global subspace
+        coordinates, of respectively origin and target subspace.
+        -let's call 'a' a vector of coordinates expressed in origin_space referential.
+        -We want to find 'b', a vector of coordinates expressed in target_space that is the best approximation of 'a'
+        -Best is understood in the sens of the L2 natural norm of the global vector space
+        -We search 'b'= arg_min ||Aa-Bb||. By taking Grad[(Aa-Bb).(Aa-Bb)] = 0, we show that:
+        This is solved by the linear equation : ( B^T * B ) b = ( B^T * A ) a.
+        """
+        # pre-compute left hand side (B^T * B) and right hand side ( B^T * A )
+        target_space_transposed = target_space_basis.transpose()
+        self._left_hand_side = np.dot(target_space_transposed, target_space_basis)
+        self._right_hand_side = np.dot(target_space_transposed, origin_space_basis)
+
+    def project_on_target_space(self, vector_in_origin_basis):
+        """
+        :param vector_in_origin_basis: vector expressed in origin_space_basis
+        :return: best projection of input vector on target_space expressed in target_space_basis
+        """
+        # solve linear equation ( B^T * B ) b = ( B^T * A ) a
+        return np.linalg.solve(self._left_hand_side, np.dot(self._right_hand_side, vector_in_origin_basis))

--- a/src/learner/learner/topic_model_converter.py
+++ b/src/learner/learner/topic_model_converter.py
@@ -10,10 +10,13 @@ class TopicModelConverter(object):
 
     def __init__(self, origin_model, target_model):
         """
-        :param origin_model: list of topics of "old" model, each topic is a list of tuple (word, weight)
-        :param target_model: list of topics of "new" model, each topic is a list of tuple (word, weight)
+        :param origin_model: struct.TopicModelDescription of the "old" model
+        :param target_model: struct.TopicModelDescription of the "new" model
         """
-        words = set(word for topic in chain(origin_model, target_model) for (word, _) in topic)  # unique words
+        words = set(topic_word.word
+                    for topic in chain(origin_model.topics, target_model.topics)
+                    for topic_word in topic.topic_words)  # unique words
+
         word_to_index = dict(izip(words, range(len(words))))
         origin_model_basis = self._build_basis_matrix(word_to_index, origin_model)
         target_model_basis = self._build_basis_matrix(word_to_index, target_model)
@@ -21,10 +24,10 @@ class TopicModelConverter(object):
 
     @staticmethod
     def _build_basis_matrix(word_to_index, model):
-        model_basis = np.zeros((len(word_to_index), len(model)))
-        for index_topic, topic in enumerate(model):
-            for word, weight in topic:
-                model_basis[word_to_index[word], index_topic] = weight
+        model_basis = np.zeros((len(word_to_index), len(model.topics)))
+        for index_topic, topic in enumerate(model.topics):
+            for topic_word in topic.topic_words:
+                model_basis[word_to_index[topic_word.word], index_topic] = topic_word.weight
         return model_basis
 
     def compute_target_vector(self, origin_vector):

--- a/src/learner/tests/test_topic_model_converter.py
+++ b/src/learner/tests/test_topic_model_converter.py
@@ -1,0 +1,104 @@
+import unittest
+import numpy as np
+from learner.topic_model_converter import TopicModelConverter
+
+
+class TopicModelConverterTests(unittest.TestCase):
+
+    def test_compute_target_vector_with_same_model_return_same_vector(self):
+        origin_model = [
+            [('orig_t1_w1', 0.8), ('orig_t1_w2', 0.1)],
+            [('orig_t2_w1', 1.0)]
+        ]
+        target_model = [
+            [('orig_t2_w1', 1.0)],
+            [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.8)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([0.25, 0.75])
+        self.assertEquals([0.75, 0.25], target_vector)
+
+    def test_compute_target_vector_with_target_encompass_origin_return_same_vector(self):
+        origin_model = [
+            [('orig_t1_w1', 0.8), ('orig_t1_w2', 0.1)],
+            [('orig_t2_w1', 1.0)]
+        ]
+        target_model = [
+            [('orig_t2_w1', 1.0)],
+            [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.8)],
+            [('target_t3_w1', 0.4), ('target_t3_w2', 0.5)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([0.25, 0.75])
+        self.assertEquals([0.75, 0.25, 0], target_vector)
+
+    def test_compute_target_vector_with_useless_dim_in_origin_return_same_vector(self):
+        origin_model = [
+            [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
+            [('orig_t2_w1', 1.0)],
+            [('orig_t1_w1', 0.5), ('orig_t3_w2', 0.4)],
+        ]
+        target_model = [
+            [('orig_t2_w1', 1.0)],
+            [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.9)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([0.25, 0.75, 0])
+        self.assertEquals([0.75, 0.25], target_vector)
+
+    def test_compute_target_vector_with_two_topics_merged_return_merged_weights(self):
+        origin_model = [
+            [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
+            [('orig_t2_w1', 1.0)]
+        ]
+        target_model = [
+            [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
+            [('orig_t1_w2', 1.0)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([0.5, 0.5])
+        self.assertEquals([0.95, 0.05], target_vector)
+
+    @staticmethod
+    def test_compute_target_vector_with_topic_split_return_split_weights():
+        origin_model = [
+            [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
+            [('orig_t1_w2', 1.0)]
+        ]
+        target_model = [
+            [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
+            [('orig_t2_w1', 1.0)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([1.0, 0.0])
+        np.testing.assert_almost_equal([0.55, 0.5], target_vector, 3)
+
+    def test_compute_target_vector_with_no_shared_word_from_used_topic_return_zero(self):
+        origin_model = [
+            [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
+            [('orig_t1_w2', 1.0)]
+        ]
+        target_model = [
+            [('target_t1_w1', 0.9), ('target_t1_w2', 0.1)],
+            [('orig_t1_w2', 1.0)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([1.0, 0.0])
+        self.assertEquals([0, 0], target_vector)
+
+    def test_compute_target_vector_with_no_shared_word_between_models_return_zero(self):
+        origin_model = [
+            [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
+            [('orig_t1_w2', 1.0)]
+        ]
+        target_model = [
+            [('target_t1_w1', 0.9), ('target_t1_w2', 0.1)],
+            [('target_t2_w1', 1.0)]
+        ]
+        converter = TopicModelConverter(origin_model, target_model)
+        target_vector = converter.compute_target_vector([0.5, 0.5])
+        self.assertEquals([0, 0], target_vector)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/learner/tests/test_topic_model_converter.py
+++ b/src/learner/tests/test_topic_model_converter.py
@@ -1,100 +1,101 @@
 import unittest
 import numpy as np
+from server.frontendstructs import TopicModelDescription
 from learner.topic_model_converter import TopicModelConverter
 
 
 class TopicModelConverterTests(unittest.TestCase):
 
     def test_compute_target_vector_with_same_model_return_same_vector(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.8), ('orig_t1_w2', 0.1)],
             [('orig_t2_w1', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('orig_t2_w1', 1.0)],
             [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.8)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([0.25, 0.75])
         self.assertEquals([0.75, 0.25], target_vector)
 
     def test_compute_target_vector_with_target_encompass_origin_return_same_vector(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.8), ('orig_t1_w2', 0.1)],
             [('orig_t2_w1', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('orig_t2_w1', 1.0)],
             [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.8)],
             [('target_t3_w1', 0.4), ('target_t3_w2', 0.5)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([0.25, 0.75])
         self.assertEquals([0.75, 0.25, 0], target_vector)
 
     def test_compute_target_vector_with_useless_dim_in_origin_return_same_vector(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
             [('orig_t2_w1', 1.0)],
             [('orig_t1_w1', 0.5), ('orig_t3_w2', 0.4)],
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('orig_t2_w1', 1.0)],
             [('orig_t1_w2', 0.1), ('orig_t1_w1', 0.9)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([0.25, 0.75, 0])
         self.assertEquals([0.75, 0.25], target_vector)
 
     def test_compute_target_vector_with_two_topics_merged_return_merged_weights(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
             [('orig_t2_w1', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
             [('orig_t1_w2', 1.0)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([0.5, 0.5])
         self.assertEquals([0.95, 0.05], target_vector)
 
     @staticmethod
     def test_compute_target_vector_with_topic_split_return_split_weights():
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
             [('orig_t1_w2', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('orig_t1_w1', 0.9), ('orig_t1_w2', 0.1)],
             [('orig_t2_w1', 1.0)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([1.0, 0.0])
         np.testing.assert_almost_equal([0.55, 0.5], target_vector, 3)
 
     def test_compute_target_vector_with_no_shared_word_from_used_topic_return_zero(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
             [('orig_t1_w2', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('target_t1_w1', 0.9), ('target_t1_w2', 0.1)],
             [('orig_t1_w2', 1.0)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([1.0, 0.0])
         self.assertEquals([0, 0], target_vector)
 
     def test_compute_target_vector_with_no_shared_word_between_models_return_zero(self):
-        origin_model = [
+        origin_model = TopicModelDescription.make_from_scratch('orig_id', [
             [('orig_t1_w1', 0.5), ('orig_t2_w1', 0.5)],
             [('orig_t1_w2', 1.0)]
-        ]
-        target_model = [
+        ])
+        target_model = TopicModelDescription.make_from_scratch('target_id', [
             [('target_t1_w1', 0.9), ('target_t1_w2', 0.1)],
             [('target_t2_w1', 1.0)]
-        ]
+        ])
         converter = TopicModelConverter(origin_model, target_model)
         target_vector = converter.compute_target_vector([0.5, 0.5])
         self.assertEquals([0, 0], target_vector)

--- a/src/orchestrator/launch_initialize_topicmodeller.py
+++ b/src/orchestrator/launch_initialize_topicmodeller.py
@@ -4,7 +4,7 @@
 import logging
 from common.JsonDocLoader import JsonDocLoader
 from topicmodeller.topicmodeller import TopicModeller
-from orchestrator.initialize_topicmodeller import initialize_topicmodeller_and_db, initialize_db
+from orchestrator.initialize_topicmodeller import initialize_topicmodeller
 
 
 logging.basicConfig(format=u'%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO,
@@ -21,19 +21,10 @@ class RepeatableHtmlDocuments(object):
             yield scraper_document.html_content
 
 
-def run_init_tm_and_db(documents_folder, tm_data_folder, num_topics):
+def run_init_tm(documents_folder, tm_data_folder, num_topics):
     html_documents = RepeatableHtmlDocuments(documents_folder)
 
-    initialize_topicmodeller_and_db(TopicModeller.make_with_html_tokenizer(), html_documents, tm_data_folder, num_topics)
+    initialize_topicmodeller(TopicModeller.make_with_html_tokenizer(), html_documents, tm_data_folder, num_topics)
 
 
-def run_init_db(tm_data_folder):
-    topic_modeller = TopicModeller.make_with_html_tokenizer()
-    topic_modeller.load(tm_data_folder)
-    initialize_db(topic_modeller)
-
-
-run_init_tm_and_db('/home/mohamed/Development/Data/gator/Scraping_11-01-2016',
-                   '/home/mohamed/Development/Data/gator/TM_LAST', 512)
-
-# run_init_db('/home/mohamed/Development/Data/gator/TM')
+run_init_tm('/home/mohamed/Development/Data/gator/Scraping_11-01-2016', '/home/mohamed/Development/Data/gator/TM_LAST', 512)

--- a/src/orchestrator/orchestrator/initialize_topicmodeller.py
+++ b/src/orchestrator/orchestrator/initialize_topicmodeller.py
@@ -23,4 +23,4 @@ def initialize_with_existing_dict(topic_modeller, html_documents, tm_data_folder
 
 def initialize_db(topic_modeller):
     feature_names = [words[0] for (_, words) in topic_modeller.topics]
-    DAL.save_features(REF_FEATURE_SET, feature_names)
+    DAL.feature_set.save_features(REF_FEATURE_SET, feature_names)

--- a/src/orchestrator/orchestrator/initialize_topicmodeller.py
+++ b/src/orchestrator/orchestrator/initialize_topicmodeller.py
@@ -1,14 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from server.dal import Dal, REF_FEATURE_SET
-from server.frontendstructs import FeatureSet
-DAL = Dal()
-
-
-def initialize_topicmodeller_and_db(topic_modeller, html_documents, tm_data_folder, num_topics):
-    initialize_topicmodeller(topic_modeller, html_documents, tm_data_folder, num_topics)
-    initialize_db(topic_modeller)
-
 
 def initialize_topicmodeller(topic_modeller, html_documents, tm_data_folder, num_topics):
     topic_modeller.initialize(html_documents, num_topics)
@@ -19,8 +10,3 @@ def initialize_with_existing_dict(topic_modeller, html_documents, tm_data_folder
     topic_modeller.load_dictionary(tm_data_folder)
     topic_modeller.initialize_model(html_documents, num_topics)
     topic_modeller.save_model(tm_data_folder)
-
-
-def initialize_db(topic_modeller):
-    feature_names = [words[0] for (_, words) in topic_modeller.topics]
-    DAL.feature_set.save_feature_set(FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names))

--- a/src/orchestrator/orchestrator/initialize_topicmodeller.py
+++ b/src/orchestrator/orchestrator/initialize_topicmodeller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from server.dal import Dal, REF_FEATURE_SET
-
+from server.frontendstructs import FeatureSet
 DAL = Dal()
 
 
@@ -23,4 +23,4 @@ def initialize_with_existing_dict(topic_modeller, html_documents, tm_data_folder
 
 def initialize_db(topic_modeller):
     feature_names = [words[0] for (_, words) in topic_modeller.topics]
-    DAL.feature_set.save_features(REF_FEATURE_SET, feature_names)
+    DAL.feature_set.save_feature_set(FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names))

--- a/src/orchestrator/orchestrator/scrap_and_learn.py
+++ b/src/orchestrator/orchestrator/scrap_and_learn.py
@@ -191,3 +191,12 @@ def _build_user_docs_accumulator(users, user_docs_max_size, dal):
     )
     user_docs_accumulator = lrn.UserDocumentsAccumulator(user_data_list, user_docs_max_size)
     return user_docs_accumulator
+
+
+# def _update_user_profiles(users, topic_modeller, dal):
+#
+#     profiles = dal.user_computed_profile.get_user_computed_profiles(users)
+#
+#
+#
+#     pass

--- a/src/orchestrator/orchestrator/scrap_and_learn.py
+++ b/src/orchestrator/orchestrator/scrap_and_learn.py
@@ -191,12 +191,3 @@ def _build_user_docs_accumulator(users, user_docs_max_size, dal):
     )
     user_docs_accumulator = lrn.UserDocumentsAccumulator(user_data_list, user_docs_max_size)
     return user_docs_accumulator
-
-
-# def _update_user_profiles(users, topic_modeller, dal):
-#
-#     profiles = dal.user_computed_profile.get_user_computed_profiles(users)
-#
-#
-#
-#     pass

--- a/src/orchestrator/orchestrator/scrap_and_learn.py
+++ b/src/orchestrator/orchestrator/scrap_and_learn.py
@@ -62,12 +62,12 @@ def _scrap_and_learn(  # pylint: disable=too-many-arguments
         keep_user_func=lambda u: False, nb_docs=-1):
     # pylint: disable=too-many-locals
     dal = Dal()
-    all_users = dal.get_all_users()
+    all_users = dal.user.get_all_users()
     users = [user for user in all_users if keep_user_func(user)]  # to filter in tests
-    users_docs = dal.get_users_docs(users)
-    users_feature_vectors = dal.get_users_feature_vectors(users)
+    users_docs = dal.user_doc.get_users_docs(users)
+    users_feature_vectors = dal.user_computed_profile.get_users_feature_vectors(users)
 
-    url_hashes = set(dal.get_recent_doc_url_hashes(seen_urls_cache_start_date))
+    url_hashes = set(dal.doc.get_recent_doc_url_hashes(seen_urls_cache_start_date))
 
     user_docs_accumulator = _build_user_docs_accumulator(users_docs, users_feature_vectors, user_docs_max_size)
     doc_chunk = [None] * docs_chunk_size
@@ -104,13 +104,13 @@ def _scrap_and_learn(  # pylint: disable=too-many-arguments
 
                 index_in_docs_chunk += 1
                 if index_in_docs_chunk == docs_chunk_size:
-                    dal.save_documents(doc_chunk)
+                    dal.doc.save_documents(doc_chunk)
                     _save_users_docs_current_state(dal, users, user_docs_accumulator)
                     doc_chunk = [None] * docs_chunk_size
                     index_in_docs_chunk = 0
 
             # exit function if scraper generator exited without error
-            dal.save_documents(doc_chunk[:index_in_docs_chunk])
+            dal.doc.save_documents(doc_chunk[:index_in_docs_chunk])
             _save_users_docs_current_state(dal, users, user_docs_accumulator)
             return
         except Exception as exception:  # pylint: disable=broad-except
@@ -137,4 +137,4 @@ def _save_users_docs_current_state(dal, users, user_docs_accumulator):
         (user, [UserDocument.make_from_scratch(lrn_user_doc.doc_id, lrn_user_doc.grade) for lrn_user_doc in lrn_user_docs])
         for user, lrn_user_docs in zip(users, lrn_users_docs)
     )
-    dal.save_users_docs(user_to_user_docs)
+    dal.user_doc.save_users_docs(user_to_user_docs)

--- a/src/orchestrator/orchestrator/updatemodel.py
+++ b/src/orchestrator/orchestrator/updatemodel.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from server.dal import Dal
+from server.frontendstructs import FeatureSet, UserProfileModelData, UserComputedProfile, FeatureVector, Document,\
+    TopicModelDescription
+from learner.topic_model_converter import TopicModelConverter
+from learner.userprofiler import UserProfiler
+
+
+def update_model_in_db(topic_modeller, all_users):
+    """
+    NB: all_users must be "all" because function will modify documents in database and if others users are using those same
+    docs, it will create a mismatch of vector model between those other users and updated docs
+    """
+    dal = Dal()
+
+    profiles = dal.user_computed_profile.get_user_computed_profiles(all_users)
+
+    target_model = TopicModelDescription.make_from_scratch(topic_modeller.get_model_id(), topic_modeller.topics)
+    target_feature_set_id = target_model.topic_model_id
+
+    _save_topic_model(dal, target_model)
+
+    feature_set_ids = list(set(profile.feature_vector.feature_set_id for profile in profiles))
+    model_converters = _get_model_converters(dal, feature_set_ids, target_model)
+    converter_dict = dict(zip(feature_set_ids, model_converters))
+
+    user_to_profile = zip(all_users, profiles)
+    updated_user_to_profiles = _get_updated_user_to_profile(converter_dict, user_to_profile, target_feature_set_id)
+    dal.user_computed_profile.save_user_computed_profiles(updated_user_to_profiles)
+
+    user_docs_by_user = dal.user_doc.get_users_docs(all_users)
+    # No need to update all docs in db, only those reachable by at least one user
+    docs = set(user_doc.document for user_docs in user_docs_by_user for user_doc in user_docs)
+    updated_docs = _get_updated_docs(docs, converter_dict, target_feature_set_id)
+    dal.doc.save_documents(updated_docs)
+
+
+def _save_topic_model(dal, model):
+    dal.topic_model.save(model)
+    target_feature_names = [topic.topic_words[0].word for topic in model.topics]
+    target_feature_set = FeatureSet.make_from_scratch(model.topic_model_id, target_feature_names, model.topic_model_id)
+    dal.feature_set.save_feature_set(target_feature_set)
+
+
+def _get_model_converters(dal, feature_set_ids, target_model):
+    feature_sets = [dal.feature_set.get_feature_set(feature_set_id) for feature_set_id in feature_set_ids]
+    models = [dal.topic_model.get(feature_set.model_id) for feature_set in feature_sets]
+    model_converters = [TopicModelConverter(model, target_model) for model in models]
+    return model_converters
+
+
+def _get_updated_docs(docs, feature_set_id_to_converter, target_feature_set_id):
+    updated_docs = []
+    for doc in docs:
+        feature_set_id = doc.feature_vector.feature_set_id
+        if feature_set_id == target_feature_set_id:
+            continue
+        converter = feature_set_id_to_converter[feature_set_id]
+        target_vector = converter.compute_target_vector(doc.feature_vector.vector)
+        target_feature_vector = FeatureVector.make_from_scratch(target_vector, target_feature_set_id)
+        updated_doc = Document.make_from_db(
+            doc.url, doc.url_hash, doc.title, doc.summary, doc.datetime, target_feature_vector)
+        updated_docs.append(updated_doc)
+    return updated_docs
+
+
+def _get_updated_user_to_profile(feature_set_id_to_converter, user_to_profile, target_feature_set_id):
+    user_profiler = UserProfiler()
+    updated_user_to_profile = []
+    for user, profile in user_to_profile:
+        feature_set_id = profile.feature_vector.feature_set_id
+        if feature_set_id == target_feature_set_id:
+            continue
+        converter = feature_set_id_to_converter[feature_set_id]
+        model_data_target = _get_updated_model_data(converter, profile.model_data)
+
+        profiler_profile = user_profiler.compute_user_profile(model_data_target, profile.datetime, [], profile.datetime)
+        target_feature_vector = FeatureVector.make_from_scratch(profiler_profile.feedback_vector, target_feature_set_id)
+        target_profile = UserComputedProfile.make_from_db(
+            target_feature_vector, model_data_target, profile.datetime)
+
+        updated_user_to_profile.append((user, target_profile))
+    return updated_user_to_profile
+
+
+def _get_updated_model_data(converter, model_data_origin):
+    explicit_target = converter.compute_target_vector(model_data_origin.explicit_feedback_vector)
+    positive_target = converter.compute_target_vector(model_data_origin.positive_feedback_vector)
+    negative_target = converter.compute_target_vector(model_data_origin.negative_feedback_vector)
+    model_data_target = UserProfileModelData.make_from_scratch(
+        explicit_target, positive_target, negative_target,
+        model_data_origin.positive_feedback_sum_coeff, model_data_origin.negative_feedback_sum_coeff)
+    return model_data_target

--- a/src/orchestrator/orchestrator/userprofileupdater.py
+++ b/src/orchestrator/orchestrator/userprofileupdater.py
@@ -12,20 +12,20 @@ def update_profiles_in_database():
     """
     This method update profile in database of all users from their new actions since last model update
     """
-    _update_profiles_in_database(DAL.get_all_users(), UserProfiler(), utcnow())
+    _update_profiles_in_database(DAL.user.get_all_users(), UserProfiler(), utcnow())
 
 
 def _update_profiles_in_database(users, profiler, now):
-    old_profiles = DAL.get_user_computed_profiles(users)
+    old_profiles = DAL.user_computed_profile.get_user_computed_profiles(users)
     actions_by_user = _get_new_actions(users, old_profiles)
     new_profiles = _build_updated_profiles(profiler, zip(old_profiles, actions_by_user), now)
-    DAL.save_user_computed_profiles(zip(users, new_profiles))
+    DAL.user_computed_profile.save_user_computed_profiles(zip(users, new_profiles))
 
 
 def _get_new_actions(users, old_profiles):
     # min requests date is unique for all users, we need to request all from this date
     min_datetime_request = min(old_profiles, key=lambda item: item.datetime).datetime
-    return DAL.get_user_actions_on_docs(users, min_datetime_request)
+    return DAL.user_action.get_user_actions_on_docs(users, min_datetime_request)
 
 
 def _build_updated_profiles(profiler, old_profile_to_actions_list, now):

--- a/src/orchestrator/tests/test_initialize_topicmodeller.py
+++ b/src/orchestrator/tests/test_initialize_topicmodeller.py
@@ -46,7 +46,7 @@ class TopicModellerTests(unittest.TestCase):
         self.assertTrue(topic_modeller.initialized)
         self.assertTrue(topic_modeller.saved)
 
-        saved_features_names = self.dal.feature_set.get_features(REF_FEATURE_SET)
+        saved_features_names = self.dal.feature_set.get_feature_set(REF_FEATURE_SET).feature_names
         self.assertEquals(saved_features_names, features_names)
 
 

--- a/src/orchestrator/tests/test_initialize_topicmodeller.py
+++ b/src/orchestrator/tests/test_initialize_topicmodeller.py
@@ -46,7 +46,7 @@ class TopicModellerTests(unittest.TestCase):
         self.assertTrue(topic_modeller.initialized)
         self.assertTrue(topic_modeller.saved)
 
-        saved_features_names = self.dal.get_features(REF_FEATURE_SET)
+        saved_features_names = self.dal.feature_set.get_features(REF_FEATURE_SET)
         self.assertEquals(saved_features_names, features_names)
 
 

--- a/src/orchestrator/tests/test_initialize_topicmodeller.py
+++ b/src/orchestrator/tests/test_initialize_topicmodeller.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from orchestrator.initialize_topicmodeller import initialize_topicmodeller_and_db
-from server.dal import Dal, REF_FEATURE_SET
+from orchestrator.initialize_topicmodeller import initialize_topicmodeller
 
 
 class MockTopicModeller(object):
@@ -27,9 +26,6 @@ class MockTopicModeller(object):
 
 class TopicModellerTests(unittest.TestCase):
 
-    def setUp(self):
-        self.dal = Dal()
-
     def test_initialize_topicmodeller(self):
         num_topics = 128
 
@@ -41,13 +37,10 @@ class TopicModellerTests(unittest.TestCase):
 
         topic_modeller = MockTopicModeller(topics, html_documents, tm_data_folder, num_topics)
 
-        initialize_topicmodeller_and_db(topic_modeller, html_documents, tm_data_folder, num_topics)
+        initialize_topicmodeller(topic_modeller, html_documents, tm_data_folder, num_topics)
 
         self.assertTrue(topic_modeller.initialized)
         self.assertTrue(topic_modeller.saved)
-
-        saved_features_names = self.dal.feature_set.get_feature_set(REF_FEATURE_SET).feature_names
-        self.assertEquals(saved_features_names, features_names)
 
 
 if __name__ == '__main__':

--- a/src/orchestrator/tests/test_scrap_and_learn.py
+++ b/src/orchestrator/tests/test_scrap_and_learn.py
@@ -57,20 +57,20 @@ class ScrapAndLearnTests(unittest.TestCase):
         # I)setup database and mocks
         # I.1) user
         user1 = struct.User.make_from_scratch("test_scrap_and_learn_user1", ["interests1"])
-        self.dal.save_user(user1, "password1")
+        self.dal.user.save_user(user1, "password1")
         self._save_dummy_profile_for_user(user1)
         user2 = struct.User.make_from_scratch("test_scrap_and_learn_user2", ["interests2"])
-        self.dal.save_user(user2, "password2")
+        self.dal.user.save_user(user2, "password2")
         self._save_dummy_profile_for_user(user2)
         # I.2) doc
         doc1 = struct.Document.make_from_scratch("url1", 'hash1', 'title1', "sum1", self.dummy_feat_vec)
         doc2 = struct.Document.make_from_scratch("url2", 'hash2', 'title2', "sum2", self.dummy_feat_vec)
-        self.dal.save_documents([doc1, doc2])
+        self.dal.doc.save_documents([doc1, doc2])
         # I.3) userDoc
         user1_user_docs = [
             struct.UserDocument.make_from_scratch(doc1, grade=0.0),  # this one should be removed
             struct.UserDocument.make_from_scratch(doc2, grade=1.0)]
-        self.dal.save_users_docs([(user1, user1_user_docs)])
+        self.dal.user_doc.save_users_docs([(user1, user1_user_docs)])
         # II) Orchestrate
         mock_saver = MockSaver()
         _scrap_and_learn(MockScraper(), mock_saver, MockTopicModeller(), docs_chunk_size=2,
@@ -78,7 +78,7 @@ class ScrapAndLearnTests(unittest.TestCase):
                          keep_user_func=lambda u: 'test_scrap_and_learn' in u.email)
 
         # III) check database and mocks
-        result_users_docs = self.dal.get_users_docs([user1, user2])
+        result_users_docs = self.dal.user_doc.get_users_docs([user1, user2])
         result_user1_docs = result_users_docs[0]
         result_user2_docs = result_users_docs[1]
         self.assertEquals(5, len(result_user1_docs))  # 5 because of user_docs_max_size=5
@@ -95,7 +95,8 @@ class ScrapAndLearnTests(unittest.TestCase):
     def _save_dummy_profile_for_user(self, user):
         feature_vector = struct.FeatureVector.make_from_scratch([1.0], "featureSetId-test_scrap_learn")
         model_data = struct.UserProfileModelData.make_empty(1)
-        self.dal.save_user_computed_profile(user, struct.UserComputedProfile.make_from_scratch(feature_vector, model_data))
+        self.dal.user_computed_profile.save_user_computed_profile(
+            user, struct.UserComputedProfile.make_from_scratch(feature_vector, model_data))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/orchestrator/tests/test_scrap_and_learn.py
+++ b/src/orchestrator/tests/test_scrap_and_learn.py
@@ -5,7 +5,7 @@ import unittest
 from orchestrator.scrap_and_learn import _scrap_and_learn
 from common.datehelper import utcnow
 import scraper.scraperstructs as scrap
-from server.dal import Dal, NULL_FEATURE_SET, REF_FEATURE_SET
+from server.dal import Dal
 import server.frontendstructs as struct
 
 
@@ -51,7 +51,9 @@ class ScrapAndLearnTests(unittest.TestCase):
 
     def setUp(self):
         self.dal = Dal()
-        self.dummy_feat_vec = struct.FeatureVector.make_from_scratch([], NULL_FEATURE_SET)
+        self.ref_feature_set_id = 'feature_set_id_ScrapAndLearnTests'
+        self.dal.feature_set.save_ref_feature_set_id(self.ref_feature_set_id)
+        self.dummy_feat_vec = struct.FeatureVector.make_from_scratch([], self.ref_feature_set_id)
 
     def test_scrap_and_learn(self):
         # I)setup database and mocks
@@ -88,8 +90,7 @@ class ScrapAndLearnTests(unittest.TestCase):
                 self.fail()
         self.assertEquals(4, len(mock_saver.saved_docs))  # MockScraper generate 4 docs
         for doc in mock_saver.saved_docs:
-            # currently, model versioning is not managed, all is set to ref
-            self.assertEquals(REF_FEATURE_SET, doc.feature_vector.feature_set_id)
+            self.assertEquals(self.ref_feature_set_id, doc.feature_vector.feature_set_id)
             self.assertEquals(MockTopicModeller.feature_vector, doc.feature_vector.vector)
 
     def _save_dummy_profile_for_user(self, user):

--- a/src/orchestrator/tests/test_updatemodel.py
+++ b/src/orchestrator/tests/test_updatemodel.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from orchestrator.updatemodel import update_model_in_db
+import server.frontendstructs as struct
+from server.dal import Dal
+
+
+class MockTopicModel(object):
+
+    def __init__(self):
+        self._model_id = 'new_model_id'
+        self.topics = [
+            [('word', 0.5)],
+            [('other_topic', 1.0)]
+        ]
+
+    def get_model_id(self):
+        return self._model_id
+
+
+class UpdateModelTests(unittest.TestCase):
+
+    def setUp(self):
+        self.dal = Dal()
+
+    def test_update_model_in_db(self):
+        # 1) save input in datastore
+        topics = [[('word', 1.0)]]
+        model_id = 'previous_model_id'
+        model = struct.TopicModelDescription.make_from_scratch(model_id, topics)
+        self.dal.topic_model.save(model)
+
+        feature_set_id = 'feature_set_id_test_update_model_in_db'
+        self.dal.feature_set.save_feature_set(struct.FeatureSet.make_from_scratch(feature_set_id, ['feat_name'], model_id))
+
+        vec_doc = [0.8]
+        url_hash = 'hash_test_update_model_in_db'
+        doc = self._get_saved_doc(feature_set_id, url_hash, vec_doc)
+
+        email = 'email_test_update_model_in_db'
+        user = struct.User.make_from_scratch(email, '')
+        self.dal.user.save_user(user, 'password')
+
+        vec_profile = [-1]
+        explicit = [2.0]
+        positive = [3.0]
+        negative = [4.0]
+        pos_sum = 1.0
+        neg_sum = 2.0
+        profile = self._get_saved_profile(user, vec_profile, feature_set_id, explicit, positive, negative, pos_sum, neg_sum)
+
+        user_doc = struct.UserDocument.make_from_scratch(doc, 0.0)
+        self.dal.user_doc.save_user_docs(user, [user_doc])
+
+        # 2) call update
+        update_model_in_db(MockTopicModel(), [user])
+
+        # 3) check datastore updates
+        new_model_id = 'new_model_id'
+        new_model = self.dal.topic_model.get(new_model_id)
+        self.assertIsNotNone(new_model)
+
+        new_feature_set = self.dal.feature_set.get_feature_set(new_model_id)
+        self.assertIsNotNone(new_feature_set)
+
+        updated_doc = self.dal.doc.get_doc(url_hash)
+        self.assertEquals(doc.datetime, updated_doc.datetime)
+        self.assertEquals(new_model_id, updated_doc.feature_vector.feature_set_id)
+        self.assertEquals([vec_doc[0] * 2, 0.0], updated_doc.feature_vector.vector)  # because weight on 'word' divided by 2
+
+        updated_profile = self.dal.user_computed_profile.get_user_computed_profiles([user])[0]
+        self.assertEquals(profile.datetime, updated_profile.datetime)
+        updated_profile_feat_vec = updated_profile.feature_vector
+        self.assertEquals(new_model_id, updated_profile_feat_vec.feature_set_id)
+        self.assertEquals([1.0, 0.0], updated_profile_feat_vec.vector)  # because no weight on 2nd topic and normalized
+
+        updated_model_data = updated_profile.model_data
+        self.assertEquals(pos_sum, updated_model_data.positive_feedback_sum_coeff)
+        self.assertEquals(neg_sum, updated_model_data.negative_feedback_sum_coeff)
+        self.assertEquals([explicit[0] * 2, 0.0], updated_model_data.explicit_feedback_vector)
+        self.assertEquals([positive[0] * 2, 0.0], updated_model_data.positive_feedback_vector)
+        self.assertEquals([negative[0] * 2, 0.0], updated_model_data.negative_feedback_vector)
+
+    def _get_saved_doc(self, feature_set_id, url_hash, vec_doc):
+        feat_vec_doc = struct.FeatureVector.make_from_scratch(vec_doc, feature_set_id)
+        doc = struct.Document.make_from_scratch('', url_hash, None, None, feat_vec_doc)
+        self.dal.doc.save_documents([doc])
+        doc = self.dal.doc.get_doc(url_hash)  # to update doc.datetime
+        return doc
+
+    def _get_saved_profile(self, user, vec_profile, feature_set_id, explicit, positive, negative, pos_sum, neg_sum):  # pylint: disable=too-many-arguments
+        # (disable pylint, nb of args here seems good trade-off)
+        feat_vec_profile = struct.FeatureVector.make_from_scratch(vec_profile, feature_set_id)
+        model_data = struct.UserProfileModelData.make_from_scratch(explicit, positive, negative, pos_sum, neg_sum)
+        profile = struct.UserComputedProfile.make_from_scratch(feat_vec_profile, model_data)
+        self.dal.user_computed_profile.save_user_computed_profile(user, profile)
+        profile = self.dal.user_computed_profile.get_user_computed_profiles([user])[0]  # to update profile.datetime
+        return profile
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/orchestrator/tests/test_updatemodel.py
+++ b/src/orchestrator/tests/test_updatemodel.py
@@ -64,6 +64,9 @@ class UpdateModelTests(unittest.TestCase):
 
         new_feature_set = self.dal.feature_set.get_feature_set(new_model_id)
         self.assertIsNotNone(new_feature_set)
+        self.assertEquals(new_model_id, new_feature_set.feature_set_id)
+        self.assertEquals(['word', 'other_topic'], new_feature_set.feature_names)
+        self.assertEquals(new_model_id, new_feature_set.model_id)
 
         updated_doc = self.dal.doc.get_doc(url_hash)
         self.assertEquals(doc.datetime, updated_doc.datetime)

--- a/src/orchestrator/tests/test_userprofileupdater.py
+++ b/src/orchestrator/tests/test_userprofileupdater.py
@@ -45,7 +45,8 @@ class UserProfileBuilderTests(unittest.TestCase):
 
     def _build_feature_set(self):
         feature_set_id = 'test_update_user_profiles_in_database'
-        self.dal.feature_set.save_feature_set(struct.FeatureSet.make_from_scratch(feature_set_id, ['feature_name']))
+        self.dal.feature_set.save_feature_set(
+            struct.FeatureSet.make_from_scratch(feature_set_id, ['feature_name'], None))
         return feature_set_id
 
     @staticmethod

--- a/src/orchestrator/tests/test_userprofileupdater.py
+++ b/src/orchestrator/tests/test_userprofileupdater.py
@@ -45,7 +45,7 @@ class UserProfileBuilderTests(unittest.TestCase):
 
     def _build_feature_set(self):
         feature_set_id = 'test_update_user_profiles_in_database'
-        self.dal.feature_set.save_features(feature_set_id, ['feature_name'])
+        self.dal.feature_set.save_feature_set(struct.FeatureSet.make_from_scratch(feature_set_id, ['feature_name']))
         return feature_set_id
 
     @staticmethod

--- a/src/orchestrator/tests/test_userprofileupdater.py
+++ b/src/orchestrator/tests/test_userprofileupdater.py
@@ -15,35 +15,37 @@ class UserProfileBuilderTests(unittest.TestCase):
     def test_update_all_user_profiles_in_database(self):
         user1 = struct.User.make_from_scratch(email='user1-test_update_user_profiles_in_database', interests=['interests1'])
         user2 = struct.User.make_from_scratch(email='user2-test_update_user_profiles_in_database', interests=['interests2'])
-        self.dal.save_user(user1, 'password1')
-        self.dal.save_user(user2, 'password2')
+        self.dal.user.save_user(user1, 'password1')
+        self.dal.user.save_user(user2, 'password2')
         feature_set_id = self._build_feature_set()
         doc = self._build_doc(feature_set_id)
-        self.dal.save_documents([doc])
+        self.dal.doc.save_documents([doc])
 
         profile1 = self._build_profile(feature_set_id)
-        self.dal.save_user_computed_profile(user1, profile1)
+        self.dal.user_computed_profile.save_user_computed_profile(user1, profile1)
 
-        self.dal.save_user_action_on_doc(user1, doc, struct.UserActionTypeOnDoc.up_vote)  # should be used because after save
-        self.dal.save_user_action_on_doc(user2, doc, struct.UserActionTypeOnDoc.up_vote)  # should not be used
+        self.dal.user_action.save_user_action_on_doc(
+            user1, doc, struct.UserActionTypeOnDoc.up_vote)  # should be used because after save
+        self.dal.user_action.save_user_action_on_doc(
+            user2, doc, struct.UserActionTypeOnDoc.up_vote)  # should not be used
 
         profile2 = self._build_profile(feature_set_id)
-        self.dal.save_user_computed_profile(user2, profile2)
+        self.dal.user_computed_profile.save_user_computed_profile(user2, profile2)
 
         # identical action
-        self.dal.save_user_action_on_doc(user1, doc, struct.UserActionTypeOnDoc.down_vote)
-        self.dal.save_user_action_on_doc(user2, doc, struct.UserActionTypeOnDoc.down_vote)
+        self.dal.user_action.save_user_action_on_doc(user1, doc, struct.UserActionTypeOnDoc.down_vote)
+        self.dal.user_action.save_user_action_on_doc(user2, doc, struct.UserActionTypeOnDoc.down_vote)
 
         update_profiles_in_database()
 
-        profiles = self.dal.get_user_computed_profiles([user1, user2])
+        profiles = self.dal.user_computed_profile.get_user_computed_profiles([user1, user2])
 
         # user1 profile should prefer doc more thant user2
         self.assertGreater(profiles[0].feature_vector.vector[0], profiles[1].feature_vector.vector[0])
 
     def _build_feature_set(self):
         feature_set_id = 'test_update_user_profiles_in_database'
-        self.dal.save_features(feature_set_id, ['feature_name'])
+        self.dal.feature_set.save_features(feature_set_id, ['feature_name'])
         return feature_set_id
 
     @staticmethod

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -154,16 +154,16 @@ class DalFeatureSet(object):
     def __init__(self, datastore_client, datastore_helper):
         self._ds_client = datastore_client
         self._helper = datastore_helper
-        self._ref_feature_set_id = u"ref_feature_set"
+        self._ref_feature_set_id = u"ref_feature_set_id"
 
     def get_ref_feature_set_id(self):
-        key = self._ds_client.key(u'SpecialFeatureSetId', self._ref_feature_set_id)
+        key = self._ds_client.key(u'ConfigKey', self._ref_feature_set_id)
         db_special_feature_set = self._ds_client.get(key)
-        return db_special_feature_set['ref_feature_set_id']
+        return db_special_feature_set['value']
 
     def save_ref_feature_set_id(self, new_ref_feature_set_id):
-        entity = self._helper.make_named_entity(u'SpecialFeatureSetId', self._ref_feature_set_id, [])
-        entity['ref_feature_set_id'] = new_ref_feature_set_id
+        entity = self._helper.make_named_entity(u'ConfigKey', self._ref_feature_set_id, [])
+        entity['value'] = new_ref_feature_set_id
         self._ds_client.put(entity)
 
     def get_feature_set(self, feature_set_id):

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -10,9 +10,6 @@ from gcloud import datastore
 from .environment import GCLOUD_PROJECT, IS_TEST_ENV
 from . import frontendstructs as struct
 
-REF_FEATURE_SET = u"ref_feature_set"
-NULL_FEATURE_SET = u"null_feature_set"
-
 
 def _to_user_action_type_on_doc(user_action_on_doc_db_string):
     if user_action_on_doc_db_string == 'up_vote':
@@ -157,6 +154,17 @@ class DalFeatureSet(object):
     def __init__(self, datastore_client, datastore_helper):
         self._ds_client = datastore_client
         self._helper = datastore_helper
+        self._ref_feature_set_id = u"ref_feature_set"
+
+    def get_ref_feature_set_id(self):
+        key = self._ds_client.key(u'SpecialFeatureSetId', self._ref_feature_set_id)
+        db_special_feature_set = self._ds_client.get(key)
+        return db_special_feature_set['ref_feature_set_id']
+
+    def save_ref_feature_set_id(self, new_ref_feature_set_id):
+        entity = self._helper.make_named_entity(u'SpecialFeatureSetId', self._ref_feature_set_id, [])
+        entity['ref_feature_set_id'] = new_ref_feature_set_id
+        self._ds_client.put(entity)
 
     def get_feature_set(self, feature_set_id):
         """
@@ -473,6 +481,7 @@ class DalUser(object):
         self._ds_client = datastore_client
         self._helper = datastore_helper
         self._dal_user_computed_profile = dal_user_computed_profile
+        self._new_user_feature_set_id = u"new_user_feature_set_id"
 
     def get_user(self, email):
         """
@@ -510,7 +519,7 @@ class DalUser(object):
         if user._user_computed_profile_db_key is None:  # pylint: disable=protected-access
 
             user_computed_profile = struct.UserComputedProfile.make_from_scratch(
-                struct.FeatureVector.make_from_scratch([], NULL_FEATURE_SET),
+                struct.FeatureVector.make_from_scratch([], self._new_user_feature_set_id),
                 struct.UserProfileModelData.make_from_scratch([], [], [], 0.0, 0.0))
             db_user_computed_profile = \
                 self._dal_user_computed_profile._to_db_user_computed_profile(  # pylint: disable=protected-access

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -157,25 +157,22 @@ class DalFeatureSet(object):
         self._ds_client = datastore_client
         self._helper = datastore_helper
 
-    def get_features(self, feature_set_id):
+    def get_feature_set(self, feature_set_id):
         """
         :param feature_set_id: string
-        :return: a list of string of feature labels of the feature_set_id. This list matches the order of the elements
-        in the feature vectors associated to this feature_set_id.
+        :return: struct.FeatureSet
         """
         db_feature_set_key = self._ds_client.key(u'FeatureSet', feature_set_id)
         db_feature_set = self._ds_client.get(db_feature_set_key)
-        return db_feature_set.get('features', [])
+        feature_names = db_feature_set.get('features', [])
+        return struct.FeatureSet.make_from_db(feature_set_id, feature_names)
 
-    def save_features(self, feature_set_id, feature_names):
+    def save_feature_set(self, feature_set):
         """
-        Save features names associated to a feature set
-        :param feature_set_id: string, id of the feature_set
-        :param feature_names: list of string
-        :return:
+        :param feature_set: struct.FeatureSet
         """
-        db_feature_set = self._helper.make_named_entity(u'FeatureSet', feature_set_id, not_indexed=('features',))
-        db_feature_set['features'] = feature_names
+        db_feature_set = self._helper.make_named_entity(u'FeatureSet', feature_set.feature_set_id, not_indexed=('features',))
+        db_feature_set['features'] = feature_set.feature_names
         self._ds_client.put(db_feature_set)
 
 

--- a/src/server/server/dal.py
+++ b/src/server/server/dal.py
@@ -109,20 +109,20 @@ def _datastore_client():
         return datastore.Client(GCLOUD_PROJECT)
 
 
-class Dal(object):
-    # Dal is a class rather than plain module functions to enable init logic in the future,
-    # but datastore client is slow to initialize, so we share it between Dal instances
-    _ds_client = _datastore_client()
+class DatastoreHelper(object):
 
-    def _make_entity(self, entity_type, not_indexed):
+    def __init__(self, datastore_client):
+        self._ds_client = datastore_client
+
+    def make_entity(self, entity_type, not_indexed):
         key = self._ds_client.key(entity_type)
         return datastore.entity.Entity(key, exclude_from_indexes=not_indexed)
 
-    def _make_named_entity(self, entity_type, key_name, not_indexed):
+    def make_named_entity(self, entity_type, key_name, not_indexed):
         key = self._ds_client.key(entity_type, key_name)
         return datastore.entity.Entity(key, exclude_from_indexes=not_indexed)
 
-    def _get_multi(self, keys):
+    def get_multi(self, keys):
         """
         Wrapper around get_multi datastore function that ensure matching of indexes between keys and retrieved entities.
         It seems to works natively at least with test gcloud server but it's not clearly specified.
@@ -132,6 +132,343 @@ class Dal(object):
         entities = self._ds_client.get_multi(keys)
         key_to_entity = dict((entity.key, entity) for entity in entities)
         return [key_to_entity[key] for key in keys]
+
+
+class Dal(object):
+    # Dal is a class rather than plain module functions to enable init logic in the future,
+    # but datastore client is slow to initialize, so we share it between Dal instances
+
+    _ds_client = _datastore_client()
+
+    def __init__(self):
+        ds_helper = DatastoreHelper(self._ds_client)
+        self.feature_set = DalFeatureSet(self._ds_client, ds_helper)
+        self.feature_vector = DalFeatureVector(self._ds_client, ds_helper)
+        self.doc = DalDoc(self._ds_client, ds_helper, self.feature_vector)
+        self.user_action = DalUserActionOnDoc(self._ds_client, ds_helper, self.doc)
+        self.user_computed_profile = DalUserComputedProfile(self._ds_client, ds_helper, self.feature_vector)
+        self.user = DalUser(self._ds_client, ds_helper, self.user_computed_profile)
+        self.user_doc = DalUserDoc(self._ds_client, ds_helper, self.doc)
+
+
+class DalFeatureSet(object):
+
+    def __init__(self, datastore_client, datastore_helper):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+
+    def get_features(self, feature_set_id):
+        """
+        :param feature_set_id: string
+        :return: a list of string of feature labels of the feature_set_id. This list matches the order of the elements
+        in the feature vectors associated to this feature_set_id.
+        """
+        db_feature_set_key = self._ds_client.key(u'FeatureSet', feature_set_id)
+        db_feature_set = self._ds_client.get(db_feature_set_key)
+        return db_feature_set.get('features', [])
+
+    def save_features(self, feature_set_id, feature_names):
+        """
+        Save features names associated to a feature set
+        :param feature_set_id: string, id of the feature_set
+        :param feature_names: list of string
+        :return:
+        """
+        db_feature_set = self._helper.make_named_entity(u'FeatureSet', feature_set_id, not_indexed=('features',))
+        db_feature_set['features'] = feature_names
+        self._ds_client.put(db_feature_set)
+
+
+class DalFeatureVector(object):
+
+    def __init__(self, datastore_client, datastore_helper):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+
+    def _to_db_feature_vector(self, feature_vector):
+        db_feature_vector = self._helper.make_entity(u'FeatureVector', not_indexed=('vector',))
+        db_feature_vector['feature_set_key'] = self._ds_client.key(u'FeatureSet', feature_vector.feature_set_id)
+        db_feature_vector['vector'] = feature_vector.vector
+        return db_feature_vector
+
+
+class DalDoc(object):
+
+    def __init__(self, datastore_client, datastore_helper, dal_feature_vector):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+        self._dal_feature_vector = dal_feature_vector
+
+    def _to_docs(self, db_doc_keys):
+        db_docs = self._helper.get_multi(db_doc_keys)
+        docs = [_to_doc(db_doc) for db_doc in db_docs]
+        return docs
+
+    def save_documents(self, documents):
+        """
+        :param documents: list of struct.Document
+        """
+        docs_with_order = [doc for doc in documents]
+        db_docs = [self._to_db_doc(doc) for doc in docs_with_order]
+        self._ds_client.put_multi(db_docs)
+        db_doc_keys = [db_doc.key for db_doc in db_docs]
+        for (doc, key) in zip(docs_with_order, db_doc_keys):
+            doc._db_key = key  # pylint: disable=protected-access
+
+    def _to_db_doc(self, doc):
+        not_indexed = ('title', 'summary', 'feature_vector')
+        db_doc = self._helper.make_named_entity('Document', doc.url_hash, not_indexed)
+        db_doc['url'] = doc.url
+        db_doc['title'] = doc.title
+        db_doc['summary'] = doc.summary
+        db_doc['feature_vector'] = self._dal_feature_vector._to_db_feature_vector(  # pylint: disable=protected-access
+            doc.feature_vector)
+        db_doc['datetime'] = datetime.datetime.utcnow()
+        return db_doc
+
+    def get_doc_by_url_hash(self, url_hash):
+        """
+        :param url_hash: string corresponding to the field 'url_hash' of a struct.Document
+        :return: struct.Document
+        """
+        db_key = self._ds_client.key('Document', url_hash)
+        db_doc = self._ds_client.get(db_key)
+        return _to_doc(db_doc)
+
+    def get_recent_doc_url_hashes(self, from_datetime):
+        """
+        :param from_datetime: datetime
+        :return: the list of hashes of docs whose datetime is after from_datetime
+        """
+        query = self._ds_client.query(kind='Document')
+        query.keys_only()
+        query.add_filter('datetime', '>', from_datetime)
+        db_doc_entities = query.fetch()
+        return [entity.key.name for entity in db_doc_entities]
+
+
+class DalUserActionOnDoc(object):
+
+    def __init__(self, datastore_client, datastore_helper, dal_doc):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+        self._dal_doc = dal_doc
+
+    def save_user_action_on_doc(self, user, document, action_on_doc):
+        """
+        :param user: frontendstructs.User
+        :param document: frontendstructs.Document
+        :param action_on_doc: frontendstructs.UserActionTypeOnDoc
+        """
+        db_action = self._to_db_user_action_on_doc(user, document, action_on_doc)
+        self._ds_client.put(db_action)
+
+    def _to_db_user_action_on_doc(self, user, document, action_on_doc):
+        db_action = self._helper.make_entity('UserActionOnDoc', not_indexed=())
+        db_action['user_key'] = user._db_key  # pylint: disable=protected-access
+        db_action['document_key'] = document._db_key  # pylint: disable=protected-access
+        db_action['action_type'] = _to_db_action_type_on_doc(action_on_doc)
+        db_action['datetime'] = datetime.datetime.utcnow()
+        return db_action
+
+    def get_user_actions_on_docs(self, users, from_datetime):
+        """
+        :param users: list of frontendstructs.User
+        :param from_datetime:
+        :return: return a list matching users input list, each element is the list of frontendstructs.UserActionOnDoc
+         for this user inserted after 'from_datetime'
+        """
+        # 1) retrieve actions from database
+        actions_query = self._ds_client.query(kind='UserActionOnDoc')
+        actions_query.add_filter('datetime', '>', from_datetime)
+        db_actions = list(actions_query.fetch())
+        # NB: we only filter on datetime (and not the users) on the query because you can't mix
+        # an 'IN something' query with other filter in datastore.
+        # Moreover, request with filter 'IN users' is limited to 30 elements and is very inefficient
+        # a long term solution if we need scalability is to replace users list by a range (min_user, max_user).
+        # fetch(10000) is not scalable either, but I won't make something complex because I think
+        # this second point would be solved if the first one (filter on user range) is solved
+
+        # 2) retrieve docs present in actions from database
+        doc_keys = list(set(action['document_key'] for action in db_actions))
+        docs = self._dal_doc._to_docs(doc_keys)  # pylint: disable=protected-access
+        doc_key_to_doc = dict(zip(doc_keys, docs))
+
+        # 3) build result, from two above database results
+        actions_by_user = [[] for _ in users]
+        user_mail_to_index = dict(zip((user.email for user in users), range(len(users))))
+        for db_action in db_actions:
+            doc = doc_key_to_doc[db_action['document_key']]
+            action = _to_user_action_on_doc(doc, db_action)
+            user_index = user_mail_to_index.get(db_action['user_key'].name)
+            if user_index is not None:  # because we did not filter query on users
+                actions_by_user[user_index].append(action)
+        return actions_by_user
+
+
+class DalUserComputedProfile(object):
+
+    def __init__(self, datastore_client, datastore_helper, dal_feature_vector):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+        self._dal_feature_vector = dal_feature_vector
+
+    def _to_db_user_profile_model_data(self, user_profile_model_data):
+        not_indexed = ('explicit_feedback_vector', 'positive_feedback_vector', 'negative_feedback_vector',
+                       'positive_feedback_sum_coeff', 'negative_feedback_sum_coeff')
+        db_user_profile_model_data = self._helper.make_entity(u'UserProfileModelData', not_indexed)
+        db_user_profile_model_data['explicit_feedback_vector'] = user_profile_model_data.explicit_feedback_vector
+        db_user_profile_model_data['positive_feedback_vector'] = user_profile_model_data.positive_feedback_vector
+        db_user_profile_model_data['negative_feedback_vector'] = user_profile_model_data.negative_feedback_vector
+        db_user_profile_model_data['positive_feedback_sum_coeff'] = user_profile_model_data.positive_feedback_sum_coeff
+        db_user_profile_model_data['negative_feedback_sum_coeff'] = user_profile_model_data.negative_feedback_sum_coeff
+
+        return db_user_profile_model_data
+
+    def _to_db_user_computed_profile(self, user_computed_profile):
+        not_indexed = ('feature_vector', 'model_data', 'datetime')
+        db_user_computed_profile = self._helper.make_entity(u'UserComputedProfile', not_indexed)
+        db_user_computed_profile['feature_vector'] =\
+            self._dal_feature_vector._to_db_feature_vector(  # pylint: disable=protected-access
+                user_computed_profile.feature_vector)
+        db_user_computed_profile['model_data'] = self._to_db_user_profile_model_data(user_computed_profile.model_data)
+        db_user_computed_profile['datetime'] = datetime.datetime.utcnow()
+        return db_user_computed_profile
+
+    def save_user_computed_profile(self, user, user_computed_profile):
+        self.save_user_computed_profiles([(user, user_computed_profile)])
+
+    def save_user_computed_profiles(self, user_profile_list):
+        """
+        :param user_profile_list: list of tuples (struct.User, struct.UserComputedProfile)
+        """
+        db_profiles = []
+        for user, user_computed_profile in user_profile_list:
+            db_profile = self._to_db_user_computed_profile(user_computed_profile)
+            # by setting as key the key previously referenced by the user, we will overwrite the previous profile in db
+            db_profile.key = user._user_computed_profile_db_key  # pylint: disable=protected-access
+            db_profiles.append(db_profile)
+        self._ds_client.put_multi(db_profiles)
+
+    def get_user_computed_profiles(self, users):
+        """
+        :param users: list of Struct.User
+        :return: list of struct.UserComputedProfile matching 'users' list
+        """
+        keys = [user._user_computed_profile_db_key for user in users]  # pylint: disable=protected-access
+        db_profiles = self._helper.get_multi(keys)
+        profiles = [_to_user_computed_profile(db_profile) for db_profile in db_profiles]
+        return profiles
+
+    def get_user_feature_vector(self, user):
+        """
+        :param user: struct.User
+        :return: struct.FeatureVector
+        """
+        return self.get_users_feature_vectors([user])[0]
+
+    def get_users_feature_vectors(self, users):
+        """
+        :param users: list of struct.User
+        :return: list of struct.FeatureVector matching 'users' list
+        """
+        # NB: this could be probably optimized by projection query if we need, but it would require to index vector property.
+        profiles = self.get_user_computed_profiles(users)
+        return [profile.feature_vector for profile in profiles]
+
+
+class DalUserDoc(object):
+
+    def __init__(self, datastore_client, datastore_helper, dal_doc):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+        self._dal_doc = dal_doc
+
+    def _to_user_docs(self, db_user_doc_set):
+        if 'user_documents' not in db_user_doc_set:  # cannot save an empty list in datastore: field would be removed
+            return []
+        db_user_docs = db_user_doc_set['user_documents']
+        db_doc_keys = [user_doc['document_key'] for user_doc in db_user_docs]
+        docs = self._dal_doc._to_docs(db_doc_keys)  # pylint: disable=protected-access
+        user_docs = [_to_user_doc(doc, db_user_doc) for doc, db_user_doc in zip(docs, db_user_docs)]
+        return user_docs
+
+    def save_user_docs(self, user, user_docs):
+        """
+        :param user: struct.user
+        :param user_docs: list of struct.UserDocument
+        :return:
+        """
+        user_doc_set_db_key = user._user_doc_set_db_key  # pylint: disable=protected-access
+        db_user_doc_set = self._ds_client.get(user_doc_set_db_key)
+        db_user_docs = self._to_db_user_docs(user_docs)
+        db_user_doc_set['user_documents'] = db_user_docs
+        self._ds_client.put(db_user_doc_set)
+
+    def _to_db_user_docs(self, user_docs):
+        db_user_docs = [self._to_db_user_doc(user_doc) for user_doc in user_docs]
+        return db_user_docs
+
+    def _to_db_user_doc(self, user_doc):
+        db_user_doc = self._helper.make_entity(u'UserDocument', not_indexed=())
+        db_user_doc['document_key'] = user_doc.document._db_key  # pylint: disable=protected-access
+        db_user_doc['grade'] = user_doc.grade
+        return db_user_doc
+
+    def save_users_docs(self, user_to_user_docs_list):
+        """
+        Save UserDocuments list associated to each User
+        :param user_to_user_docs_list: list of tuples (User, List of UserDocument)
+        """
+        user_set_db_keys = []
+        users_docs = []
+        for user, user_docs in user_to_user_docs_list:
+            user_set_db_keys.append(user._user_doc_set_db_key)  # pylint: disable=protected-access
+            users_docs.append(user_docs)
+        db_user_sets = self._helper.get_multi(user_set_db_keys)
+        for (db_user_set, user_docs) in zip(db_user_sets, users_docs):
+            db_user_set['user_documents'] = self._to_db_user_docs(user_docs)
+        self._ds_client.put_multi(db_user_sets)
+
+    def get_user_docs(self, user):
+        """
+        :param user: struct.User
+        :return: list of struct.UserDocument
+        """
+        user_doc_set = self._ds_client.get(user._user_doc_set_db_key)  # pylint: disable=protected-access
+        return self._to_user_docs(user_doc_set)
+
+    def get_users_docs(self, users):
+        """
+        :param users: list of struct.User
+        :return: list matching 'users' list, each list being a list of struct.UserDocument
+        """
+        def to_user_doc(db_user_doc):
+            return _to_user_doc(keys_to_docs[db_user_doc['document_key']], db_user_doc)
+
+        def db_set_to_user_doc_list(db_user_doc_set):
+            db_user_docs = db_docs(db_user_doc_set)
+            return [to_user_doc(db_user_doc) for db_user_doc in db_user_docs]
+
+        def db_docs(db_user_doc_set):
+            return db_user_doc_set.get('user_documents', [])
+
+        user_doc_set_db_keys = [user._user_doc_set_db_key for user in users]  # pylint: disable=protected-access
+        db_user_doc_sets = self._helper.get_multi(user_doc_set_db_keys)
+        doc_keys_set = {user_doc['document_key'] for user_doc_set in db_user_doc_sets for user_doc in db_docs(user_doc_set)}
+        doc_keys_list = list(doc_keys_set)
+        docs = self._dal_doc._to_docs(doc_keys_list)  # pylint: disable=protected-access
+        keys_to_docs = dict(zip(doc_keys_list, docs))
+
+        return [db_set_to_user_doc_list(db_user_doc_set) for db_user_doc_set in db_user_doc_sets]
+
+
+class DalUser(object):
+
+    def __init__(self, datastore_client, datastore_helper, dal_user_computed_profile):
+        self._ds_client = datastore_client
+        self._helper = datastore_helper
+        self._dal_user_computed_profile = dal_user_computed_profile
 
     def get_user(self, email):
         """
@@ -162,7 +499,7 @@ class Dal(object):
         save a user into the database, if it's newly created, db_keys will be initialized
         """
         if user._user_doc_set_db_key is None:  # pylint: disable=protected-access
-            user_doc_set_db = self._make_entity('UserDocumentSet', not_indexed=('user_documents',))
+            user_doc_set_db = self._helper.make_entity('UserDocumentSet', not_indexed=('user_documents',))
             user_doc_set_db['user_documents'] = []
             self._ds_client.put(user_doc_set_db)
             user._user_doc_set_db_key = user_doc_set_db.key  # pylint: disable=protected-access
@@ -171,7 +508,9 @@ class Dal(object):
             user_computed_profile = struct.UserComputedProfile.make_from_scratch(
                 struct.FeatureVector.make_from_scratch([], NULL_FEATURE_SET),
                 struct.UserProfileModelData.make_from_scratch([], [], [], 0.0, 0.0))
-            db_user_computed_profile = self._to_db_user_computed_profile(user_computed_profile)
+            db_user_computed_profile = \
+                self._dal_user_computed_profile._to_db_user_computed_profile(  # pylint: disable=protected-access
+                    user_computed_profile)
             self._ds_client.put(db_user_computed_profile)
             user._user_computed_profile_db_key = db_user_computed_profile.key  # pylint: disable=protected-access
 
@@ -181,273 +520,10 @@ class Dal(object):
 
     def _to_db_user(self, user, password):
         not_indexed = ('password', 'interests', 'user_doc_set_key', 'user_computed_profile_key')
-        db_user = self._make_named_entity('User', user.email, not_indexed)
+        db_user = self._helper.make_named_entity('User', user.email, not_indexed)
         db_user['email'] = user.email
         db_user['password'] = password
         db_user['interests'] = user.interests
         db_user['user_doc_set_key'] = user._user_doc_set_db_key  # pylint: disable=protected-access
         db_user['user_computed_profile_key'] = user._user_computed_profile_db_key  # pylint: disable=protected-access
         return db_user
-
-    def get_features(self, feature_set_id):
-        """
-        :param feature_set_id: string
-        :return: a list of string of feature labels of the feature_set_id. This list matches the order of the elements
-        in the feature vectors associated to this feature_set_id.
-        """
-        db_feature_set_key = self._ds_client.key(u'FeatureSet', feature_set_id)
-        db_feature_set = self._ds_client.get(db_feature_set_key)
-        return db_feature_set.get('features', [])
-
-    def save_features(self, feature_set_id, feature_names):
-        """
-        Save features names associated to a feature set
-        :param feature_set_id: string, id of the feature_set
-        :param feature_names: list of string
-        :return:
-        """
-        db_feature_set = self._make_named_entity(u'FeatureSet', feature_set_id, not_indexed=('features',))
-        db_feature_set['features'] = feature_names
-        self._ds_client.put(db_feature_set)
-
-    def _to_db_user_profile_model_data(self, user_profile_model_data):
-        not_indexed = ('explicit_feedback_vector', 'positive_feedback_vector', 'negative_feedback_vector',
-                       'positive_feedback_sum_coeff', 'negative_feedback_sum_coeff')
-        db_user_profile_model_data = self._make_entity(u'UserProfileModelData', not_indexed)
-        db_user_profile_model_data['explicit_feedback_vector'] = user_profile_model_data.explicit_feedback_vector
-        db_user_profile_model_data['positive_feedback_vector'] = user_profile_model_data.positive_feedback_vector
-        db_user_profile_model_data['negative_feedback_vector'] = user_profile_model_data.negative_feedback_vector
-        db_user_profile_model_data['positive_feedback_sum_coeff'] = user_profile_model_data.positive_feedback_sum_coeff
-        db_user_profile_model_data['negative_feedback_sum_coeff'] = user_profile_model_data.negative_feedback_sum_coeff
-
-        return db_user_profile_model_data
-
-    def _to_db_user_computed_profile(self, user_computed_profile):
-        not_indexed = ('feature_vector', 'model_data', 'datetime')
-        db_user_computed_profile = self._make_entity(u'UserComputedProfile', not_indexed)
-        db_user_computed_profile['feature_vector'] = self._to_db_feature_vector(user_computed_profile.feature_vector)
-        db_user_computed_profile['model_data'] = self._to_db_user_profile_model_data(user_computed_profile.model_data)
-        db_user_computed_profile['datetime'] = datetime.datetime.utcnow()
-        return db_user_computed_profile
-
-    def _to_db_feature_vector(self, feature_vector):
-        db_feature_vector = self._make_entity(u'FeatureVector', not_indexed=('vector',))
-        db_feature_vector['feature_set_key'] = self._ds_client.key(u'FeatureSet', feature_vector.feature_set_id)
-        db_feature_vector['vector'] = feature_vector.vector
-        return db_feature_vector
-
-    def save_user_computed_profile(self, user, user_computed_profile):
-        self.save_user_computed_profiles([(user, user_computed_profile)])
-
-    def save_user_computed_profiles(self, user_profile_list):
-        """
-        :param user_profile_list: list of tuples (struct.User, struct.UserComputedProfile)
-        """
-        db_profiles = []
-        for user, user_computed_profile in user_profile_list:
-            db_profile = self._to_db_user_computed_profile(user_computed_profile)
-            # by setting as key the key previously referenced by the user, we will overwrite the previous profile in db
-            db_profile.key = user._user_computed_profile_db_key  # pylint: disable=protected-access
-            db_profiles.append(db_profile)
-        self._ds_client.put_multi(db_profiles)
-
-    def get_user_computed_profiles(self, users):
-        """
-        :param users: list of Struct.User
-        :return: list of struct.UserComputedProfile matching 'users' list
-        """
-        keys = [user._user_computed_profile_db_key for user in users]  # pylint: disable=protected-access
-        db_profiles = self._get_multi(keys)
-        profiles = [_to_user_computed_profile(db_profile) for db_profile in db_profiles]
-        return profiles
-
-    def get_user_feature_vector(self, user):
-        """
-        :param user: struct.User
-        :return: struct.FeatureVector
-        """
-        return self.get_users_feature_vectors([user])[0]
-
-    def get_users_feature_vectors(self, users):
-        """
-        :param users: list of struct.User
-        :return: list of struct.FeatureVector matching 'users' list
-        """
-        # NB: this could be probably optimized by projection query if we need, but it would require to index vector property.
-        profiles = self.get_user_computed_profiles(users)
-        return [profile.feature_vector for profile in profiles]
-
-    def _to_user_docs(self, db_user_doc_set):
-        if 'user_documents' not in db_user_doc_set:  # cannot save an empty list in datastore: field would be removed
-            return []
-        db_user_docs = db_user_doc_set['user_documents']
-        db_doc_keys = [user_doc['document_key'] for user_doc in db_user_docs]
-        docs = self._to_docs(db_doc_keys)
-        user_docs = [_to_user_doc(doc, db_user_doc) for doc, db_user_doc in zip(docs, db_user_docs)]
-        return user_docs
-
-    def _to_docs(self, db_doc_keys):
-        db_docs = self._get_multi(db_doc_keys)
-        docs = [_to_doc(db_doc) for db_doc in db_docs]
-        return docs
-
-    def save_user_docs(self, user, user_docs):
-        """
-        :param user: struct.user
-        :param user_docs: list of struct.UserDocument
-        :return:
-        """
-        user_doc_set_db_key = user._user_doc_set_db_key  # pylint: disable=protected-access
-        db_user_doc_set = self._ds_client.get(user_doc_set_db_key)
-        db_user_docs = self._to_db_user_docs(user_docs)
-        db_user_doc_set['user_documents'] = db_user_docs
-        self._ds_client.put(db_user_doc_set)
-
-    def _to_db_user_docs(self, user_docs):
-        db_user_docs = [self._to_db_user_doc(user_doc) for user_doc in user_docs]
-        return db_user_docs
-
-    def _to_db_user_doc(self, user_doc):
-        db_user_doc = self._make_entity(u'UserDocument', not_indexed=())
-        db_user_doc['document_key'] = user_doc.document._db_key  # pylint: disable=protected-access
-        db_user_doc['grade'] = user_doc.grade
-        return db_user_doc
-
-    def save_users_docs(self, user_to_user_docs_list):
-        """
-        Save UserDocuments list associated to each User
-        :param user_to_user_docs_list: list of tuples (User, List of UserDocument)
-        """
-        user_set_db_keys = []
-        users_docs = []
-        for user, user_docs in user_to_user_docs_list:
-            user_set_db_keys.append(user._user_doc_set_db_key)  # pylint: disable=protected-access
-            users_docs.append(user_docs)
-        db_user_sets = self._get_multi(user_set_db_keys)
-        for (db_user_set, user_docs) in zip(db_user_sets, users_docs):
-            db_user_set['user_documents'] = self._to_db_user_docs(user_docs)
-        self._ds_client.put_multi(db_user_sets)
-
-    def get_user_docs(self, user):
-        """
-        :param user: struct.User
-        :return: list of struct.UserDocument
-        """
-        user_doc_set = self._ds_client.get(user._user_doc_set_db_key)  # pylint: disable=protected-access
-        return self._to_user_docs(user_doc_set)
-
-    def get_users_docs(self, users):
-        """
-        :param users: list of struct.User
-        :return: list matching 'users' list, each list being a list of struct.UserDocument
-        """
-        def to_user_doc(db_user_doc):
-            return _to_user_doc(keys_to_docs[db_user_doc['document_key']], db_user_doc)
-
-        def db_set_to_user_doc_list(db_user_doc_set):
-            db_user_docs = db_docs(db_user_doc_set)
-            return [to_user_doc(db_user_doc) for db_user_doc in db_user_docs]
-
-        def db_docs(db_user_doc_set):
-            return db_user_doc_set.get('user_documents', [])
-
-        user_doc_set_db_keys = [user._user_doc_set_db_key for user in users]  # pylint: disable=protected-access
-        db_user_doc_sets = self._get_multi(user_doc_set_db_keys)
-        doc_keys_set = {user_doc['document_key'] for user_doc_set in db_user_doc_sets for user_doc in db_docs(user_doc_set)}
-        doc_keys_list = list(doc_keys_set)
-        docs = self._to_docs(doc_keys_list)
-        keys_to_docs = dict(zip(doc_keys_list, docs))
-
-        return [db_set_to_user_doc_list(db_user_doc_set) for db_user_doc_set in db_user_doc_sets]
-
-    def save_documents(self, documents):
-        """
-        :param documents: list of struct.Document
-        """
-        docs_with_order = [doc for doc in documents]
-        db_docs = [self._to_db_doc(doc) for doc in docs_with_order]
-        self._ds_client.put_multi(db_docs)
-        db_doc_keys = [db_doc.key for db_doc in db_docs]
-        for (doc, key) in zip(docs_with_order, db_doc_keys):
-            doc._db_key = key  # pylint: disable=protected-access
-
-    def _to_db_doc(self, doc):
-        not_indexed = ('title', 'summary', 'feature_vector')
-        db_doc = self._make_named_entity('Document', doc.url_hash, not_indexed)
-        db_doc['url'] = doc.url
-        db_doc['title'] = doc.title
-        db_doc['summary'] = doc.summary
-        db_doc['feature_vector'] = self._to_db_feature_vector(doc.feature_vector)
-        db_doc['datetime'] = datetime.datetime.utcnow()
-        return db_doc
-
-    def get_doc_by_url_hash(self, url_hash):
-        """
-        :param url_hash: string corresponding to the field 'url_hash' of a struct.Document
-        :return: struct.Document
-        """
-        db_key = self._ds_client.key('Document', url_hash)
-        db_doc = self._ds_client.get(db_key)
-        return _to_doc(db_doc)
-
-    def get_recent_doc_url_hashes(self, from_datetime):
-        """
-        :param from_datetime: datetime
-        :return: the list of hashes of docs whose datetime is after from_datetime
-        """
-        query = self._ds_client.query(kind='Document')
-        query.keys_only()
-        query.add_filter('datetime', '>', from_datetime)
-        db_doc_entities = query.fetch()
-        return [entity.key.name for entity in db_doc_entities]
-
-    def save_user_action_on_doc(self, user, document, action_on_doc):
-        """
-        :param user: frontendstructs.User
-        :param document: frontendstructs.Document
-        :param action_on_doc: frontendstructs.UserActionTypeOnDoc
-        """
-        db_action = self._to_db_user_action_on_doc(user, document, action_on_doc)
-        self._ds_client.put(db_action)
-
-    def _to_db_user_action_on_doc(self, user, document, action_on_doc):
-        db_action = self._make_entity('UserActionOnDoc', not_indexed=())
-        db_action['user_key'] = user._db_key  # pylint: disable=protected-access
-        db_action['document_key'] = document._db_key  # pylint: disable=protected-access
-        db_action['action_type'] = _to_db_action_type_on_doc(action_on_doc)
-        db_action['datetime'] = datetime.datetime.utcnow()
-        return db_action
-
-    def get_user_actions_on_docs(self, users, from_datetime):
-        """
-        :param users: list of frontendstructs.User
-        :param from_datetime:
-        :return: return a list matching users input list, each element is the list of frontendstructs.UserActionOnDoc
-         for this user inserted after 'from_datetime'
-        """
-        # 1) retrieve actions from database
-        actions_query = self._ds_client.query(kind='UserActionOnDoc')
-        actions_query.add_filter('datetime', '>', from_datetime)
-        db_actions = list(actions_query.fetch())
-        # NB: we only filter on datetime (and not the users) on the query because you can't mix
-        # an 'IN something' query with other filter in datastore.
-        # Moreover, request with filter 'IN users' is limited to 30 elements and is very inefficient
-        # a long term solution if we need scalability is to replace users list by a range (min_user, max_user).
-        # fetch(10000) is not scalable either, but I won't make something complex because I think
-        # this second point would be solved if the first one (filter on user range) is solved
-
-        # 2) retrieve docs present in actions from database
-        doc_keys = list(set(action['document_key'] for action in db_actions))
-        docs = self._to_docs(doc_keys)
-        doc_key_to_doc = dict(zip(doc_keys, docs))
-
-        # 3) build result, from two above database results
-        actions_by_user = [[] for _ in users]
-        user_mail_to_index = dict(zip((user.email for user in users), range(len(users))))
-        for db_action in db_actions:
-            doc = doc_key_to_doc[db_action['document_key']]
-            action = _to_user_action_on_doc(doc, db_action)
-            user_index = user_mail_to_index.get(db_action['user_key'].name)
-            if user_index is not None:  # because we did not filter query on users
-                actions_by_user[user_index].append(action)
-        return actions_by_user

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-class Document(object):  # pylint: disable=too-many-instance-attributes
+class Document(object):
 
     @staticmethod
-    def make_from_db(url, url_hash, title, summary, datetime, db_key, feature_vector):  # pylint: disable=too-many-arguments
-        return Document(url, url_hash, title, summary, datetime, db_key, feature_vector)
+    def make_from_db(url, url_hash, title, summary, datetime, feature_vector):
+        return Document(url, url_hash, title, summary, datetime, feature_vector)
 
     @staticmethod
     def make_from_scratch(url, url_hash, title, summary, feature_vector):
@@ -18,13 +18,12 @@ class Document(object):  # pylint: disable=too-many-instance-attributes
         :return:
         """
         return Document(
-            url, url_hash, title, summary, datetime=None, db_key=None, feature_vector=feature_vector)
+            url, url_hash, title, summary, datetime=None, feature_vector=feature_vector)
 
-    def __init__(self, url, url_hash, title, summary, datetime, db_key, feature_vector):  # pylint: disable=too-many-arguments
+    def __init__(self, url, url_hash, title, summary, datetime, feature_vector):
         self.url = url
         self.url_hash = url_hash
         self.title = title
-        self._db_key = db_key
         self.summary = summary
         self.datetime = datetime
         self.feature_vector = feature_vector

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -63,6 +63,21 @@ class User(object):
         self._user_computed_profile_db_key = user_computed_profile_db_key
 
 
+class FeatureSet(object):
+
+    @staticmethod
+    def make_from_scratch(feature_set_id, feature_names):
+        return FeatureSet(feature_set_id, feature_names)
+
+    @staticmethod
+    def make_from_db(feature_set_id, feature_names):
+        return FeatureSet(feature_set_id, feature_names)
+
+    def __init__(self, feature_set_id, feature_names):
+        self.feature_set_id = feature_set_id
+        self.feature_names = feature_names
+
+
 class FeatureVector(object):
 
     @staticmethod

--- a/src/server/server/frontendstructs.py
+++ b/src/server/server/frontendstructs.py
@@ -65,16 +65,17 @@ class User(object):
 class FeatureSet(object):
 
     @staticmethod
-    def make_from_scratch(feature_set_id, feature_names):
-        return FeatureSet(feature_set_id, feature_names)
+    def make_from_scratch(feature_set_id, feature_names, model_id):
+        return FeatureSet(feature_set_id, feature_names, model_id)
 
     @staticmethod
-    def make_from_db(feature_set_id, feature_names):
-        return FeatureSet(feature_set_id, feature_names)
+    def make_from_db(feature_set_id, feature_names, model_id):
+        return FeatureSet(feature_set_id, feature_names, model_id)
 
-    def __init__(self, feature_set_id, feature_names):
+    def __init__(self, feature_set_id, feature_names, model_id):
         self.feature_set_id = feature_set_id
         self.feature_names = feature_names
+        self.model_id = model_id
 
 
 class FeatureVector(object):
@@ -169,3 +170,31 @@ class UserProfileModelData(object):
         self.negative_feedback_vector = negative_feedback_vector
         self.positive_feedback_sum_coeff = positive_feedback_sum_coeff
         self.negative_feedback_sum_coeff = negative_feedback_sum_coeff
+
+
+class TopicModelDescription(object):
+
+    class Topic(object):
+
+        def __init__(self, topic_words):
+            self.topic_words = topic_words
+
+    class TopicWord(object):
+
+        def __init__(self, word, weight):
+            self.word = word
+            self.weight = weight
+
+    def __init__(self, topic_model_id, topics):
+        self.topic_model_id = topic_model_id
+        self.topics = topics
+
+    @staticmethod
+    def make_from_scratch(topic_model_id, topics):
+        """
+        :param topic_model_id: id of the topic model
+        :param topics: list of topic, each topic is a list of tuple (word, weight)
+        :return:
+        """
+        return TopicModelDescription(topic_model_id, [TopicModelDescription.Topic(
+            [TopicModelDescription.TopicWord(word, weight) for word, weight in topic]) for topic in topics])

--- a/src/server/server/handlers.py
+++ b/src/server/server/handlers.py
@@ -29,7 +29,7 @@ def unset_connected_user():
 
 def get_connected_user():
     if 'email' in session:
-        return DAL.get_user(session['email'])
+        return DAL.user.get_user(session['email'])
     return None
 
 
@@ -39,7 +39,7 @@ def login():
         email = request.form['email']
         password = request.form['password']
 
-        (user, user_password) = DAL.get_user_and_password(email)
+        (user, user_password) = DAL.user.get_user_and_password(email)
         if user is not None and passwordhelpers.is_password_valid_for_user(user_password, password):
             set_connected_user(user)
             return redirect('/')
@@ -57,7 +57,7 @@ def login():
 def home():
     user = get_connected_user()
     if user is not None:
-        user_docs = DAL.get_user_docs(user)
+        user_docs = DAL.user_doc.get_user_docs(user)
         links = [Link(url_hash=user_doc.document.url_hash, text=user_doc.document.title) for user_doc in user_docs]
         actions_mapping = {'click_link': struct.UserActionTypeOnDoc.click_link,
                            'up_vote': struct.UserActionTypeOnDoc.up_vote,
@@ -76,7 +76,7 @@ def register():
             email = request.form['email']
             password = request.form['password']
             interests = request.form['interests'].splitlines()
-            user = DAL.get_user(email)
+            user = DAL.user.get_user(email)
             if user is None:
                 user = structinit.create_user_in_db(email, interests, password, DAL)
                 set_connected_user(user)
@@ -105,8 +105,8 @@ def disconnect():
 def link(action_type_on_doc, url_hash):
     user = get_connected_user()
     if user is not None:
-        document = DAL.get_doc_by_url_hash(url_hash)
-        DAL.save_user_action_on_doc(user, document, action_type_on_doc)
+        document = DAL.doc.get_doc_by_url_hash(url_hash)
+        DAL.user_action.save_user_action_on_doc(user, document, action_type_on_doc)
         if action_type_on_doc == struct.UserActionTypeOnDoc.click_link:
             return redirect(document.url.encode('utf-8'))
         else:

--- a/src/server/server/handlers.py
+++ b/src/server/server/handlers.py
@@ -105,7 +105,7 @@ def disconnect():
 def link(action_type_on_doc, url_hash):
     user = get_connected_user()
     if user is not None:
-        document = DAL.doc.get_doc_by_url_hash(url_hash)
+        document = DAL.doc.get_doc(url_hash)
         DAL.user_action.save_user_action_on_doc(user, document, action_type_on_doc)
         if action_type_on_doc == struct.UserActionTypeOnDoc.click_link:
             return redirect(document.url.encode('utf-8'))

--- a/src/server/server/structinit.py
+++ b/src/server/server/structinit.py
@@ -9,7 +9,7 @@ def create_user_in_db(email, interests, password, dal):
     dal.user.save_user(user, passwordhelpers.hash_password(password))
 
     # Create an empty profile for the newly created user
-    features_set = dal.feature_set.get_features(REF_FEATURE_SET)
+    features_set = dal.feature_set.get_feature_set(REF_FEATURE_SET).feature_names
     feature_vector = struct.FeatureVector.make_from_scratch([1] * len(features_set), REF_FEATURE_SET)
     model_data = struct.UserProfileModelData.make_empty(len(features_set))
     profile = struct.UserComputedProfile.make_from_scratch(feature_vector, model_data)

--- a/src/server/server/structinit.py
+++ b/src/server/server/structinit.py
@@ -6,13 +6,13 @@ from . import passwordhelpers
 
 def create_user_in_db(email, interests, password, dal):
     user = struct.User.make_from_scratch(email, interests)
-    dal.save_user(user, passwordhelpers.hash_password(password))
+    dal.user.save_user(user, passwordhelpers.hash_password(password))
 
     # Create an empty profile for the newly created user
-    features_set = dal.get_features(REF_FEATURE_SET)
+    features_set = dal.feature_set.get_features(REF_FEATURE_SET)
     feature_vector = struct.FeatureVector.make_from_scratch([1] * len(features_set), REF_FEATURE_SET)
     model_data = struct.UserProfileModelData.make_empty(len(features_set))
     profile = struct.UserComputedProfile.make_from_scratch(feature_vector, model_data)
 
-    dal.save_user_computed_profiles([(user, profile)])
+    dal.user_computed_profile.save_user_computed_profiles([(user, profile)])
     return user

--- a/src/server/server/structinit.py
+++ b/src/server/server/structinit.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from .dal import REF_FEATURE_SET
 from . import frontendstructs as struct
 from . import passwordhelpers
 
@@ -9,9 +8,11 @@ def create_user_in_db(email, interests, password, dal):
     dal.user.save_user(user, passwordhelpers.hash_password(password))
 
     # Create an empty profile for the newly created user
-    features_set = dal.feature_set.get_feature_set(REF_FEATURE_SET).feature_names
-    feature_vector = struct.FeatureVector.make_from_scratch([1] * len(features_set), REF_FEATURE_SET)
-    model_data = struct.UserProfileModelData.make_empty(len(features_set))
+    ref_feature_set_id = dal.feature_set.get_ref_feature_set_id()
+    feature_set = dal.feature_set.get_feature_set(ref_feature_set_id)
+    set_length = len(feature_set.feature_names)
+    feature_vector = struct.FeatureVector.make_from_scratch([1] * set_length, feature_set.feature_set_id)
+    model_data = struct.UserProfileModelData.make_empty(set_length)
     profile = struct.UserComputedProfile.make_from_scratch(feature_vector, model_data)
 
     dal.user_computed_profile.save_user_computed_profiles([(user, profile)])

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -13,17 +13,19 @@ class DalTests(unittest.TestCase):
     def setUp(self):
         self.dal = sdal.Dal()
 
-    def test_save_then_get_features(self):
-        self.dal.feature_set.save_features(feature_set_id='set', feature_names=['desc1', 'desc2'])
-        feature_set = self.dal.feature_set.get_features('set')
-        self.assertEquals('desc1', feature_set[0])
-        self.assertEquals('desc2', feature_set[1])
+    def test_save_then_get_feature_set(self):
+        self.dal.feature_set.save_feature_set(
+            struct.FeatureSet.make_from_scratch(feature_set_id='set', feature_names=['desc1', 'desc2']))
+        feature_set = self.dal.feature_set.get_feature_set('set')
+        self.assertEquals('set', feature_set.feature_set_id)
+        self.assertEquals('desc1', feature_set.feature_names[0])
+        self.assertEquals('desc2', feature_set.feature_names[1])
 
     def test_save_then_get_empty_features(self):
-        self.dal.feature_set.save_features(
-            feature_set_id='test_save_then_get_empty_features_feature_set_id', feature_names=[])
-        feature_set = self.dal.feature_set.get_features('test_save_then_get_empty_features_feature_set_id')
-        self.assertEquals([], feature_set)
+        self.dal.feature_set.save_feature_set(struct.FeatureSet.make_from_scratch(
+            feature_set_id='test_save_then_get_empty_features_feature_set_id', feature_names=[]))
+        feature_set = self.dal.feature_set.get_feature_set('test_save_then_get_empty_features_feature_set_id')
+        self.assertEquals([], feature_set.feature_names)
 
     def test_get_user_with_unknown_user_should_return_none(self):
         self.assertIsNone(self.dal.user.get_user('missing_user'))
@@ -320,7 +322,8 @@ class DalTests(unittest.TestCase):
         self.assertTrue(doc2.url_hash in url_hashes)
 
     def build_dummy_db_feature_set(self):
-        self.dal.feature_set.save_features(feature_set_id='set', feature_names=['desc2', 'desc1'])
+        self.dal.feature_set.save_feature_set(
+            struct.FeatureSet.make_from_scratch(feature_set_id='set', feature_names=['desc2', 'desc1']))
         return 'set'
 
 

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -115,7 +115,7 @@ class DalTests(unittest.TestCase):
         self.dal.doc.save_documents(expected_docs)
 
         for expected_doc in expected_docs:
-            result_doc = self.dal.doc.get_doc_by_url_hash(expected_doc.url_hash)
+            result_doc = self.dal.doc.get_doc(expected_doc.url_hash)
             self._assert_doc_equals(expected_doc, result_doc)
 
     def test_save_two_docs_with_same_url_hash_override_first(self):
@@ -126,7 +126,7 @@ class DalTests(unittest.TestCase):
         self.dal.doc.save_documents([doc1])
         self.dal.doc.save_documents([doc2])
 
-        result_doc = self.dal.doc.get_doc_by_url_hash(doc1.url_hash)
+        result_doc = self.dal.doc.get_doc(doc1.url_hash)
         self._assert_doc_equals(doc2, result_doc)
 
     def test_save_then_get_user_computed_profiles(self):
@@ -204,7 +204,6 @@ class DalTests(unittest.TestCase):
         self.assertEquals(expected_doc.url, result_doc.url)
         self.assertEquals(expected_doc.url_hash, result_doc.url_hash)
         self.assertEquals(expected_doc.title, result_doc.title)
-        self.assertEquals(expected_doc._db_key, result_doc._db_key)
         self.assertEquals(expected_doc.summary, result_doc.summary)
         self.assertEquals(expected_doc.feature_vector.vector, result_doc.feature_vector.vector)
         self.assertEquals(expected_doc.feature_vector.feature_set_id, result_doc.feature_vector.feature_set_id)
@@ -301,11 +300,19 @@ class DalTests(unittest.TestCase):
             if not enum_name.startswith("__"):
                 self.assertEquals(enum_value, sdal._to_user_action_type_on_doc(sdal._to_db_action_type_on_doc(enum_value)))
 
-    def test_get_doc_by_url_hash(self):
-        doc = self.make_dummy_doc('test_get_doc_by_url_hash')
+    def test_get_doc(self):
+        doc = self.make_dummy_doc('test_get_doc')
         self.dal.doc.save_documents([doc])
-        result_doc = self.dal.doc.get_doc_by_url_hash(doc.url_hash)
+        result_doc = self.dal.doc.get_doc(doc.url_hash)
         self._assert_doc_equals(doc, result_doc)
+
+    def test_get_docs(self):
+        doc1 = self.make_dummy_doc('test_get_docs_1')
+        doc2 = self.make_dummy_doc('test_get_docs_2')
+        self.dal.doc.save_documents([doc1, doc2])
+        result_docs = self.dal.doc.get_docs([doc1.url_hash, doc2.url_hash])
+        self._assert_doc_equals(doc1, result_docs[0])
+        self._assert_doc_equals(doc2, result_docs[1])
 
     def test_get_recent_doc_url_hashes(self):
 

--- a/src/server/tests/test_dal.py
+++ b/src/server/tests/test_dal.py
@@ -13,6 +13,12 @@ class DalTests(unittest.TestCase):
     def setUp(self):
         self.dal = sdal.Dal()
 
+    def test_save_then_get_ref_feature_set_id(self):
+        expected_id = 'test_save_then_get_ref_feature_set_id'
+        self.dal.feature_set.save_ref_feature_set_id(expected_id)
+        result_id = self.dal.feature_set.get_ref_feature_set_id()
+        self.assertEquals(expected_id, result_id)
+
     def test_save_then_get_feature_set(self):
         self.dal.feature_set.save_feature_set(
             struct.FeatureSet.make_from_scratch(
@@ -147,7 +153,8 @@ class DalTests(unittest.TestCase):
         self.dal.user.save_user(user, 'test_get_empty_user_computed_profiles_password')
         result_profile = self.dal.user_computed_profile.get_user_computed_profiles([user])[0]
         expected_profile = struct.UserComputedProfile.make_from_scratch(
-            feature_vector=struct.FeatureVector.make_from_scratch([], sdal.NULL_FEATURE_SET),
+            feature_vector=struct.FeatureVector.make_from_scratch(
+                [], self.dal.user._new_user_feature_set_id),  # pylint: disable=protected-access
             model_data=struct.UserProfileModelData.make_from_scratch([], [], [], 0, 0)
         )
 

--- a/src/server/tests/test_handlers.py
+++ b/src/server/tests/test_handlers.py
@@ -49,9 +49,9 @@ class DalUserDocMock(object):
 
 class DalFeatureSetMock(object):
 
-    def get_features(self, feature_set_id):  # pylint: disable=unused-argument, no-self-use
+    def get_feature_set(self, feature_set_id):  # pylint: disable=unused-argument, no-self-use
         if feature_set_id == REF_FEATURE_SET:
-            return ['label1']
+            return struct.FeatureSet.make_from_db(feature_set_id, ['label1'])
         return None
 
 

--- a/src/server/tests/test_handlers.py
+++ b/src/server/tests/test_handlers.py
@@ -66,7 +66,7 @@ class DalUserComputedProfileMock(object):
 
 class DalDocMock(object):
 
-    def get_doc_by_url_hash(self, url_hash):  # pylint: disable=unused-argument, no-self-use
+    def get_doc(self, url_hash):  # pylint: disable=unused-argument, no-self-use
         if url_hash == 'url_hash':
             return struct.Document.make_from_scratch('url3', None, 'title3', None, None)
         return None

--- a/src/server/tests/test_handlers.py
+++ b/src/server/tests/test_handlers.py
@@ -51,7 +51,7 @@ class DalFeatureSetMock(object):
 
     def get_feature_set(self, feature_set_id):  # pylint: disable=unused-argument, no-self-use
         if feature_set_id == REF_FEATURE_SET:
-            return struct.FeatureSet.make_from_db(feature_set_id, ['label1'])
+            return struct.FeatureSet.make_from_db(feature_set_id, ['label1'], None)
         return None
 
 

--- a/src/server/tests/test_handlers.py
+++ b/src/server/tests/test_handlers.py
@@ -3,7 +3,6 @@
 
 import unittest
 from flask import Flask
-from server.dal import REF_FEATURE_SET
 import server.frontendstructs as struct
 import server.handlers as handlers
 import server.passwordhelpers as pswd
@@ -49,8 +48,12 @@ class DalUserDocMock(object):
 
 class DalFeatureSetMock(object):
 
-    def get_feature_set(self, feature_set_id):  # pylint: disable=unused-argument, no-self-use
-        if feature_set_id == REF_FEATURE_SET:
+    @staticmethod
+    def get_ref_feature_set_id():
+        return 'ref_feature_set_DalFeatureSetMock'
+
+    def get_feature_set(self, feature_set_id):
+        if feature_set_id == self.get_ref_feature_set_id():
             return struct.FeatureSet.make_from_db(feature_set_id, ['label1'], None)
         return None
 

--- a/src/server/tests/test_structinit.py
+++ b/src/server/tests/test_structinit.py
@@ -3,7 +3,7 @@
 
 import unittest
 from server.structinit import create_user_in_db
-from server.dal import Dal, REF_FEATURE_SET
+from server.dal import Dal
 from server.frontendstructs import FeatureSet
 import server.passwordhelpers as pswd
 
@@ -12,13 +12,16 @@ class StructInitTests(unittest.TestCase):
 
     def setUp(self):
         self.dal = Dal()
-        self.dal.feature_set.save_feature_set(
-            FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4'], model_id=None))
 
     def test_create_user_in_db(self):
         email = 'email_test_create_user_in_db'
         interests = ['test_create_user_in_db_interest1', 'test_create_user_in_db_interest2']
         password = 'password_test_create_user_in_db'
+        ref_feature_set_id = 'test_create_user_in_db'
+        self.dal.feature_set.save_feature_set(
+            FeatureSet.make_from_scratch(ref_feature_set_id, feature_names=['f1', 'f2', 'f3'], model_id=None))
+        self.dal.feature_set.save_ref_feature_set_id(ref_feature_set_id)
+
         user = create_user_in_db(email, interests, password, self.dal)
 
         user_from_db, hash_password_from_db = self.dal.user.get_user_and_password(email)
@@ -29,9 +32,9 @@ class StructInitTests(unittest.TestCase):
         self.assertEquals(interests, user.interests)
         self.assertEquals(interests, user_from_db.interests)
         self.assertEquals(pswd.hash_password(password), hash_password_from_db)
-        self.assertEquals(REF_FEATURE_SET, profile.feature_vector.feature_set_id)
-        self.assertEquals([1, 1, 1, 1], profile.feature_vector.vector)
-        self.assertEquals(4, len(profile.model_data.positive_feedback_vector))
+        self.assertEquals(ref_feature_set_id, profile.feature_vector.feature_set_id)
+        self.assertEquals([1, 1, 1], profile.feature_vector.vector)
+        self.assertEquals(3, len(profile.model_data.positive_feedback_vector))
 
 
 if __name__ == '__main__':

--- a/src/server/tests/test_structinit.py
+++ b/src/server/tests/test_structinit.py
@@ -4,6 +4,7 @@
 import unittest
 from server.structinit import create_user_in_db
 from server.dal import Dal, REF_FEATURE_SET
+from server.frontendstructs import FeatureSet
 import server.passwordhelpers as pswd
 
 
@@ -11,7 +12,8 @@ class StructInitTests(unittest.TestCase):
 
     def setUp(self):
         self.dal = Dal()
-        self.dal.feature_set.save_features(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4'])
+        self.dal.feature_set.save_feature_set(
+            FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4']))
 
     def test_create_user_in_db(self):
         email = 'email_test_create_user_in_db'

--- a/src/server/tests/test_structinit.py
+++ b/src/server/tests/test_structinit.py
@@ -13,7 +13,7 @@ class StructInitTests(unittest.TestCase):
     def setUp(self):
         self.dal = Dal()
         self.dal.feature_set.save_feature_set(
-            FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4']))
+            FeatureSet.make_from_scratch(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4'], model_id=None))
 
     def test_create_user_in_db(self):
         email = 'email_test_create_user_in_db'

--- a/src/server/tests/test_structinit.py
+++ b/src/server/tests/test_structinit.py
@@ -11,7 +11,7 @@ class StructInitTests(unittest.TestCase):
 
     def setUp(self):
         self.dal = Dal()
-        self.dal.save_features(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4'])
+        self.dal.feature_set.save_features(REF_FEATURE_SET, feature_names=['f1', 'f2', 'f3', 'f4'])
 
     def test_create_user_in_db(self):
         email = 'email_test_create_user_in_db'
@@ -19,8 +19,8 @@ class StructInitTests(unittest.TestCase):
         password = 'password_test_create_user_in_db'
         user = create_user_in_db(email, interests, password, self.dal)
 
-        user_from_db, hash_password_from_db = self.dal.get_user_and_password(email)
-        profile = self.dal.get_user_computed_profiles([user])[0]
+        user_from_db, hash_password_from_db = self.dal.user.get_user_and_password(email)
+        profile = self.dal.user_computed_profile.get_user_computed_profiles([user])[0]
 
         self.assertEquals(email, user.email)
         self.assertEquals(email, user_from_db.email)

--- a/src/topicmodeller/tests/test_topicmodeller.py
+++ b/src/topicmodeller/tests/test_topicmodeller.py
@@ -26,12 +26,12 @@ class TopicModellerTests(unittest.TestCase):
         topic_modeller.initialize(docs, num_topics=2)
 
         # check number of topics is expected
-        self.assertEquals(2, len(topic_modeller.topics))
+        self.assertEquals(2, len(topic_modeller.get_topics()))
 
         # check most recurrent words are selected topics (green, orange)
         index_orange = -1
         index_green = -1
-        for index, topic in zip(range(2), topic_modeller.topics):
+        for index, topic in zip(range(2), topic_modeller.get_topics()):
             (word, _) = topic[0]
             if word == u'orange':
                 index_orange = index
@@ -45,7 +45,7 @@ class TopicModellerTests(unittest.TestCase):
         # -same topic, different docs
         (ok1, classification_after_init_doc1) = topic_modeller.classify(doc1)
         self.assertTrue(ok1)
-        self.assertEquals(len(topic_modeller.topics), len(classification_after_init_doc1))
+        self.assertEquals(len(topic_modeller.get_topics()), len(classification_after_init_doc1))
         (ok2, classification_after_init_doc2) = topic_modeller.classify(doc2)
         self.assertTrue(ok2)
         self.assertTrue(classification_after_init_doc1[index_orange] > classification_after_init_doc1[index_green])
@@ -62,7 +62,7 @@ class TopicModellerTests(unittest.TestCase):
 
         (ok1_reload, classification_after_load_doc1) = deserialized_topic_modeller.classify(doc1)
         self.assertTrue(ok1_reload)
-        self.assertEquals(len(topic_modeller.topics), len(classification_after_load_doc1))
+        self.assertEquals(len(topic_modeller.get_topics()), len(classification_after_load_doc1))
         for after_init, after_load in zip(classification_after_init_doc1, classification_after_load_doc1):
             self.assertAlmostEqual(after_init, after_load, places=4)
 
@@ -73,12 +73,13 @@ class TopicModellerTests(unittest.TestCase):
         nb_topics = 2
         words = ["word" + str(i) for i in range(dict_size)]
         topic_modeller = self._build_topic_model(nb_docs, nb_topics, nb_words_by_doc, words)
-        self.assertEquals(nb_topics, len(topic_modeller.topics))
-        for topic in topic_modeller.topics:
-            self.assertEquals(100, len(topic))  # we keep 100 most significant words for each topics
+        self.assertEquals(nb_topics, len(topic_modeller.get_topics()))
+        for topic in topic_modeller.get_topics():
+            # we keep topic_modeller._nb_words_by_topic most significant words for each topics
+            self.assertEquals(topic_modeller._nb_words_by_topic, len(topic))
             for word, weight in topic:
                 self.assertTrue(word in words)
-                self.assertTrue(0 < weight < 1)
+                self.assertTrue(weight > 0)
 
     def test_get_model_id(self):
         nb_docs = 3

--- a/src/topicmodeller/tests/test_topicmodeller.py
+++ b/src/topicmodeller/tests/test_topicmodeller.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import random
 import unittest
 
 from topicmodeller.topicmodeller import TopicModeller
@@ -30,10 +31,11 @@ class TopicModellerTests(unittest.TestCase):
         # check most recurrent words are selected topics (green, orange)
         index_orange = -1
         index_green = -1
-        for index, topic in topic_modeller.topics:
-            if topic[0] == u'orange':
+        for index, topic in zip(range(2), topic_modeller.topics):
+            (word, _) = topic[0]
+            if word == u'orange':
                 index_orange = index
-            if topic[0] == u'green':
+            if word == u'green':
                 index_green = index
         self.assertNotEquals(-1, index_orange)
         self.assertNotEquals(-1, index_green)
@@ -63,6 +65,56 @@ class TopicModellerTests(unittest.TestCase):
         self.assertEquals(len(topic_modeller.topics), len(classification_after_load_doc1))
         for after_init, after_load in zip(classification_after_init_doc1, classification_after_load_doc1):
             self.assertAlmostEqual(after_init, after_load, places=4)
+
+    def test_topic_field(self):
+        nb_docs = 5
+        nb_words_by_doc = 150
+        dict_size = 150
+        nb_topics = 2
+        words = ["word" + str(i) for i in range(dict_size)]
+        topic_modeller = self._build_topic_model(nb_docs, nb_topics, nb_words_by_doc, words)
+        self.assertEquals(nb_topics, len(topic_modeller.topics))
+        for topic in topic_modeller.topics:
+            self.assertEquals(100, len(topic))  # we keep 100 most significant words for each topics
+            for word, weight in topic:
+                self.assertTrue(word in words)
+                self.assertTrue(0 < weight < 1)
+
+    def test_get_model_id(self):
+        nb_docs = 3
+        nb_words_by_doc = 20
+        dict_size = 50
+        nb_topics = 2
+        words = ["word" + str(i) for i in range(dict_size)]
+        topic_modeller = self._build_topic_model(nb_docs, nb_topics, nb_words_by_doc, words)
+        topic_modeller_same = self._build_topic_model(nb_docs, nb_topics, nb_words_by_doc, words)
+        topic_modeller_diff = self._build_topic_model(nb_docs, nb_topics, nb_words_by_doc + 1, words)
+
+        model_id = topic_modeller.get_model_id()
+        model_id_same = topic_modeller_same.get_model_id()
+        self.assertEquals(model_id, model_id_same)
+        self.assertNotEquals(model_id, topic_modeller_diff)
+
+        directory = os.path.dirname(os.path.abspath(__file__))
+        topic_modeller.save(directory)
+        deserialized_topic_modeller = TopicModeller(self.MockTokenizer())
+        deserialized_topic_modeller.load(directory)
+        model_id_after_load = deserialized_topic_modeller.get_model_id()
+        self.assertEquals(model_id, model_id_after_load)
+
+    def _build_topic_model(self, nb_docs, nb_topics, nb_words_by_doc, words):
+        docs = []
+        random.seed(0)
+        for _ in range(nb_docs):
+            doc = ""
+            for _ in range(nb_words_by_doc):
+                doc += " " + random.choice(words)
+            docs.append(doc)
+        topic_modeller = TopicModeller(self.MockTokenizer())
+        topic_modeller._remove_optimizations = True  # pylint: disable=protected-access
+        topic_modeller.initialize(docs, num_topics=nb_topics)
+        return topic_modeller
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/topicmodeller/topicmodeller/topicmodeller.py
+++ b/src/topicmodeller/topicmodeller/topicmodeller.py
@@ -24,6 +24,7 @@ class _MultiIterator(object):
 
 
 class TopicModeller(object):
+    _nb_words_by_topic = 100
 
     @classmethod
     def make_with_html_tokenizer(cls):
@@ -160,31 +161,30 @@ class TopicModeller(object):
         # are "cached" on a set (O(1)).
         self._dictionary_words = set(self._dictionary.values())
 
-    @property
-    def topics(self):
+    def get_topics(self):
         """
         :return: list of topics, each topic is a list of tuple (word, weight) by descending order of weight
         """
-        # topics field is lazy loaded because it is rarely used and show_topic function is slow
-        if self._topics is None:
-            # Monkey patch to optimize show_topic: it calls slow function LdaState.get_lambda() for each call to show_topic
-            # but get_lambda() is independent of topic so it can be called once and cached
-            models.ldamodel.LdaState.gensim_get_lambda = models.ldamodel.LdaState.get_lambda
-            models.ldamodel.LdaState.get_lambda = _gensim_get_lambda_monkey_patch
-            self._topics = [self._lda.show_topic(topicid=i, topn=100) for i in range(self._lda.num_topics)]
-            models.ldamodel.LdaState.get_lambda = models.ldamodel.LdaState.gensim_get_lambda
-            # free cached result
-            self._lda.state._cached_get_lambda_result = None  # pylint: disable=protected-access
-        return self._topics
+        # Monkey patch to optimize show_topic: it calls slow function LdaState.get_lambda() for each call to show_topic
+        # but get_lambda() is independent of topic so it can be called once and cached
+        models.ldamodel.LdaState.gensim_get_lambda = models.ldamodel.LdaState.get_lambda
+        models.ldamodel.LdaState.get_lambda = _gensim_get_lambda_monkey_patch
+        topics = [self._lda.show_topic(topicid=i, topn=self._nb_words_by_topic) for i in range(self._lda.num_topics)]
+        models.ldamodel.LdaState.get_lambda = models.ldamodel.LdaState.gensim_get_lambda
+        # Delete gensim_get_lambda and the attribute dynamically created by _gensim_get_lambda_monkey_patch
+        # (leave a clean structure).
+        del models.ldamodel.LdaState.gensim_get_lambda
+        del self._lda.state._cached_get_lambda_result # pylint: disable=protected-access, no-member
+
+        return topics
 
     def get_model_id(self):
         """
         :return: string: identifier of the topic model.
         """
-        # Nb: hash is computed only with world and not weight to prevent possible rounding errors
-        # between several machines, the risk that two models have the exact same words in same order being negligible
-        topics = self.topics
-        string_topics = ''.join(word for topic in topics for word, weight in topic)
+        # Nb: hash is computed only with world and not weight to prevent possible rounding errors between several machines,
+        # The risk that two models have the exact same words in same order being negligible
+        string_topics = ''.join(word for topic in self.get_topics() for word, _ in topic)
         hash_topic_words = hash_safe(string_topics)
         return hash_topic_words
 

--- a/tools/start_tests.sh
+++ b/tools/start_tests.sh
@@ -6,6 +6,7 @@
 tools/start_server.sh
 
 if [ "$1" = "cover" ]; then
+	export COVERAGE='True'
 	coverage run --source=src --omit=*tests* -m py.test src
 else
 	py.test src


### PR DESCRIPTION
Will be useful for migration (but still needs a high level script to update database)

This will eventually fix the issue that userprofiler fails as soon as there is a user with a profile vector of invalid size 
